### PR TITLE
feat: configurable request timeout + dead code cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ OPENCLAW_URL=http://127.0.0.1:18789
 # Bearer token for OpenClaw gateway authentication (must match gateway.auth.token)
 OPENCLAW_GATEWAY_TOKEN=
 
+# Request timeout in milliseconds (default: 120000 = 2 minutes)
+# Increase for complex operations that take longer (e.g., 300000 = 5 minutes)
+# OPENCLAW_TIMEOUT_MS=120000
+
 # =============================================================================
 # Server Settings (SSE transport only)
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Add to your Claude Desktop config:
       "args": ["openclaw-mcp"],
       "env": {
         "OPENCLAW_URL": "http://127.0.0.1:18789",
-        "OPENCLAW_GATEWAY_TOKEN": "your-gateway-token"
+        "OPENCLAW_GATEWAY_TOKEN": "your-gateway-token",
+        "OPENCLAW_TIMEOUT_MS": "300000"
       }
     }
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ All configuration can be done via environment variables. Copy `.env.example` to 
 |----------|-------------|---------|
 | `OPENCLAW_URL` | OpenClaw gateway URL | `http://127.0.0.1:18789` |
 | `OPENCLAW_GATEWAY_TOKEN` | Bearer token for gateway authentication | (none) |
+| `OPENCLAW_TIMEOUT_MS` | Request timeout in milliseconds | `120000` (2 min) |
 
 ### Server Settings (SSE transport)
 

--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -46,31 +46,6 @@ describe('logger', () => {
     });
   });
 
-  describe('logDebug', () => {
-    it('does not log when DEBUG is not set', async () => {
-      vi.stubEnv('DEBUG', 'false');
-      vi.stubEnv('NODE_ENV', 'production');
-      const { logDebug } = await loadLogger();
-      logDebug('debug info');
-      expect(consoleSpy).not.toHaveBeenCalled();
-    });
-
-    it('logs when DEBUG=true', async () => {
-      vi.stubEnv('DEBUG', 'true');
-      const { logDebug } = await loadLogger();
-      logDebug('debug info');
-      expect(consoleSpy).toHaveBeenCalledWith('[openclaw-mcp] DEBUG: debug info');
-    });
-
-    it('logs when NODE_ENV=development', async () => {
-      vi.stubEnv('DEBUG', 'false');
-      vi.stubEnv('NODE_ENV', 'development');
-      const { logDebug } = await loadLogger();
-      logDebug('debug info');
-      expect(consoleSpy).toHaveBeenCalledWith('[openclaw-mcp] DEBUG: debug info');
-    });
-  });
-
   describe('sanitization', () => {
     it('redacts Bearer tokens', async () => {
       const { log } = await loadLogger();

--- a/src/__tests__/utils/validation.test.ts
+++ b/src/__tests__/utils/validation.test.ts
@@ -4,9 +4,6 @@ import {
   validateString,
   validateMessage,
   validateId,
-  validateKey,
-  validatePositiveInt,
-  validateOptionalPositiveInt,
 } from '../../utils/validation.js';
 
 describe('validateInputIsObject', () => {
@@ -115,89 +112,5 @@ describe('validateId', () => {
   it('uses provided field name in errors', () => {
     const result = validateId(42, 'taskId');
     expect(result.error).toContain('taskId');
-  });
-});
-
-describe('validateKey', () => {
-  it('validates with 256 char limit', () => {
-    const result = validateKey('my-key');
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe('my-key');
-  });
-
-  it('rejects keys exceeding 256 chars', () => {
-    const result = validateKey('a'.repeat(257));
-    expect(result.valid).toBe(false);
-  });
-
-  it('uses "key" as the field name', () => {
-    const result = validateKey(42);
-    expect(result.error).toContain('key');
-  });
-});
-
-describe('validatePositiveInt', () => {
-  it('accepts positive integers', () => {
-    const result = validatePositiveInt(1, 'count');
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe(1);
-  });
-
-  it('accepts large positive integers', () => {
-    const result = validatePositiveInt(999, 'count');
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe(999);
-  });
-
-  it('rejects zero', () => {
-    const result = validatePositiveInt(0, 'count');
-    expect(result.valid).toBe(false);
-  });
-
-  it('rejects negative numbers', () => {
-    const result = validatePositiveInt(-5, 'count');
-    expect(result.valid).toBe(false);
-  });
-
-  it('rejects floats', () => {
-    const result = validatePositiveInt(1.5, 'count');
-    expect(result.valid).toBe(false);
-  });
-
-  it('rejects null and undefined', () => {
-    expect(validatePositiveInt(null, 'count').valid).toBe(false);
-    expect(validatePositiveInt(undefined, 'count').valid).toBe(false);
-    expect(validatePositiveInt(null, 'count').error).toContain('required');
-  });
-
-  it('rejects non-numbers', () => {
-    expect(validatePositiveInt('5', 'count').valid).toBe(false);
-  });
-});
-
-describe('validateOptionalPositiveInt', () => {
-  it('returns default value for null/undefined', () => {
-    const result = validateOptionalPositiveInt(undefined, 'limit', 50);
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe(50);
-  });
-
-  it('returns default value for null', () => {
-    const result = validateOptionalPositiveInt(null, 'limit', 50);
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe(50);
-  });
-
-  it('accepts valid positive integers', () => {
-    const result = validateOptionalPositiveInt(10, 'limit', 50);
-    expect(result.valid).toBe(true);
-    expect(result.value).toBe(10);
-  });
-
-  it('rejects invalid values', () => {
-    expect(validateOptionalPositiveInt(0, 'limit', 50).valid).toBe(false);
-    expect(validateOptionalPositiveInt(-1, 'limit', 50).valid).toBe(false);
-    expect(validateOptionalPositiveInt(1.5, 'limit', 50).valid).toBe(false);
-    expect(validateOptionalPositiveInt('5', 'limit', 50).valid).toBe(false);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ export interface CliArgs {
   transport: 'stdio' | 'sse';
   port: number;
   host: string;
+  timeout: number;
   authEnabled: boolean;
   clientId: string | undefined;
   clientSecret: string | undefined;
@@ -47,6 +48,11 @@ export function parseArguments(version: string): CliArgs {
       description: 'Host for SSE server',
       default: process.env.HOST || '0.0.0.0',
     })
+    .option('timeout', {
+      type: 'number',
+      description: 'Request timeout in milliseconds',
+      default: parseInt(process.env.OPENCLAW_TIMEOUT_MS || '120000', 10),
+    })
     .option('auth', {
       type: 'boolean',
       description: 'Enable OAuth authentication (SSE mode)',
@@ -81,6 +87,7 @@ export function parseArguments(version: string): CliArgs {
     transport: argv.transport as 'stdio' | 'sse',
     port: argv.port,
     host: argv.host,
+    timeout: argv.timeout,
     authEnabled: argv.auth,
     clientId: argv['client-id'] as string | undefined,
     clientSecret: argv['client-secret'] as string | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { createSSEServer, type SSEServerConfig } from './server/sse.js';
 const args = parseArguments(SERVER_VERSION);
 
 // Create OpenClaw client
-const client = new OpenClawClient(args.openclawUrl, args.gatewayToken);
+const client = new OpenClawClient(args.openclawUrl, args.gatewayToken, args.timeout);
 
 // Shared dependencies for tool registration
 const deps: ToolRegistrationDeps = {
@@ -25,6 +25,7 @@ async function main() {
   log(`OpenClaw URL: ${args.openclawUrl}`);
   log(`Transport: ${args.transport}`);
   log(`Gateway token: ${args.gatewayToken ? 'configured' : 'not set'}`);
+  log(`Request timeout: ${args.timeout}ms`);
 
   if (args.transport === 'sse') {
     const sseConfig: SSEServerConfig = {

--- a/src/mcp/tasks/index.ts
+++ b/src/mcp/tasks/index.ts
@@ -1,1 +1,0 @@
-export { taskManager, type Task, type TaskStatus, type TaskCreateOptions } from './manager.js';

--- a/src/mcp/tasks/manager.ts
+++ b/src/mcp/tasks/manager.ts
@@ -15,7 +15,7 @@ export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cance
 
 export interface Task {
   id: string;
-  type: 'chat' | 'custom';
+  type: 'chat';
   status: TaskStatus;
   input: unknown;
   result?: string;
@@ -28,7 +28,7 @@ export interface Task {
 }
 
 export interface TaskCreateOptions {
-  type: 'chat' | 'custom';
+  type: 'chat';
   input: unknown;
   sessionId?: string;
   priority?: number;

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -12,5 +12,4 @@ export {
   handleOpenclawTaskList,
   handleOpenclawTaskCancel,
   startTaskProcessor,
-  stopTaskProcessor,
 } from './tasks.js';

--- a/src/mcp/tools/tasks.ts
+++ b/src/mcp/tools/tasks.ts
@@ -100,13 +100,9 @@ async function processTask(task: Task, client: OpenClawClient): Promise<void> {
   taskManager.updateStatus(task.id, 'running');
 
   try {
-    if (task.type === 'chat') {
-      const input = task.input as { message: string; session_id?: string };
-      const response = await client.chat(input.message, input.session_id);
-      taskManager.updateStatus(task.id, 'completed', response.response);
-    } else {
-      taskManager.updateStatus(task.id, 'failed', undefined, 'Unknown task type');
-    }
+    const input = task.input as { message: string; session_id?: string };
+    const response = await client.chat(input.message, input.session_id);
+    taskManager.updateStatus(task.id, 'completed', response.response);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : 'Unknown error';
     taskManager.updateStatus(task.id, 'failed', undefined, errorMsg);
@@ -137,12 +133,6 @@ export function startTaskProcessor(client: OpenClawClient): void {
     processorRunning = false;
   });
   log('Task processor started');
-}
-
-export function stopTaskProcessor(): void {
-  processorRunning = false;
-  processorClient = null;
-  log('Task processor stopped');
 }
 
 // ============================================================================
@@ -245,7 +235,13 @@ export async function handleOpenclawTaskStatus(
   return successResponse(JSON.stringify(response, null, 2));
 }
 
-const VALID_TASK_STATUSES = ['pending', 'running', 'completed', 'failed', 'cancelled'] as const;
+const VALID_TASK_STATUSES: readonly TaskStatus[] = [
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+];
 
 export async function handleOpenclawTaskList(
   _client: OpenClawClient,

--- a/src/openclaw/client.ts
+++ b/src/openclaw/client.ts
@@ -5,7 +5,7 @@ import type {
   OpenAIChatCompletionResponse,
 } from './types.js';
 
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_RESPONSE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
 export class OpenClawClient {

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -1,10 +1,5 @@
 // OpenAI-compatible API types
 
-export interface OpenAIChatMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
-
 export interface OpenAIChatCompletionResponse {
   id: string;
   object: string;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,3 @@
-const DEBUG = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development';
-
 /**
  * Patterns that may indicate sensitive data in log messages.
  * These are redacted to prevent credential leaks in logs.
@@ -33,11 +31,5 @@ export function logError(message: string, error?: unknown): void {
     } else {
       console.error('[openclaw-mcp] (non-Error object thrown)');
     }
-  }
-}
-
-export function logDebug(message: string): void {
-  if (DEBUG) {
-    console.error(`[openclaw-mcp] DEBUG: ${sanitizeLogMessage(message)}`);
   }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,18 +14,11 @@ const CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/;
 
 const MAX_MESSAGE_LENGTH = 100_000;
 const MAX_ID_LENGTH = 256;
-const MAX_KEY_LENGTH = 256;
 
 /** Validation result with all properties always present */
 export interface StringValidation {
   valid: boolean;
   value: string;
-  error: string;
-}
-
-export interface NumberValidation {
-  valid: boolean;
-  value: number;
   error: string;
 }
 
@@ -83,41 +76,4 @@ export function validateMessage(value: unknown): StringValidation {
  */
 export function validateId(value: unknown, fieldName: string): StringValidation {
   return validateString(value, fieldName, MAX_ID_LENGTH);
-}
-
-/**
- * Validate a key string (max 256 chars).
- */
-export function validateKey(value: unknown): StringValidation {
-  return validateString(value, 'key', MAX_KEY_LENGTH);
-}
-
-/**
- * Validate a positive integer.
- */
-export function validatePositiveInt(value: unknown, fieldName: string): NumberValidation {
-  if (value === undefined || value === null) {
-    return { valid: false, value: 0, error: `${fieldName} is required` };
-  }
-  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
-    return { valid: false, value: 0, error: `${fieldName} must be a positive integer` };
-  }
-  return { valid: true, value, error: '' };
-}
-
-/**
- * Validate an optional positive integer with a default value.
- */
-export function validateOptionalPositiveInt(
-  value: unknown,
-  fieldName: string,
-  defaultValue: number
-): NumberValidation {
-  if (value === undefined || value === null) {
-    return { valid: true, value: defaultValue, error: '' };
-  }
-  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
-    return { valid: false, value: 0, error: `${fieldName} must be a positive integer` };
-  }
-  return { valid: true, value, error: '' };
 }


### PR DESCRIPTION
## Summary
- Add `OPENCLAW_TIMEOUT_MS` env var and `--timeout` CLI flag (default bumped from 30s to 120s)
- Remove dead code: `custom` task type, `stopTaskProcessor`, `OpenAIChatMessage` type, unused validation functions (`validateKey`, `validatePositiveInt`, `validateOptionalPositiveInt`), `logDebug`, unused `mcp/tasks/index.ts` barrel export
- Type `VALID_TASK_STATUSES` as `readonly TaskStatus[]` to prevent drift

## Test plan
- [x] `npm run check:all` passes (lint, typecheck, 115 tests, build)

Closes #9