### PR TITLE
fix: correct package.json path in constants.ts

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const pkg = require('../../package.json') as { version: string };
+const pkg = require('../package.json') as { version: string };
 
 export const SERVER_NAME = 'openclaw-mcp';
 export const SERVER_VERSION = pkg.version;


### PR DESCRIPTION
After TypeScript compilation, dist/index.js resolves relative paths from /app/dist/. The path ../../package.json would escape the /app/ directory. Change to ../package.json so it correctly resolves to /app/package.json.

https://claude.ai/code/session_01RJx9TXmm95gwXh2U7NTsLF