### PR TITLE
feat(auth): add MCP_DANGEROUSLY_ALLOW_DCR for Cursor/Windsurf compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,13 @@ MCP_CLIENT_SECRET=
 # Allowed OAuth redirect URIs (comma-separated)
 # If not set, any redirect_uri is accepted (not recommended for production)
 # MCP_REDIRECT_URIS=https://claude.ai/oauth/callback
+
+# Enable OAuth Dynamic Client Registration (RFC 7591) — DEV ONLY.
+# Cursor and Windsurf require DCR to connect. When enabled alongside the
+# auto-approve authorization flow, any client that can reach the server can
+# register itself and obtain a token. The server refuses to start with DCR on
+# and a non-loopback bind unless you also set MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true.
+# MCP_CLIENT_ID + MCP_CLIENT_SECRET are still required (DCR augments the
+# pre-configured client, it does not replace it).
+# MCP_DANGEROUSLY_ALLOW_DCR=false
+# MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,8 @@ The server uses the MCP SDK's built-in OAuth 2.1 server with authorization code 
 | `MCP_CLIENT_SECRET` | OAuth client secret                                         | When auth enabled          |
 | `MCP_ISSUER_URL`    | OAuth issuer URL override (e.g., `https://mcp.example.com`) | When behind HTTPS proxy    |
 | `MCP_REDIRECT_URIS` | Allowed redirect URIs (comma-separated)                     | Recommended for production |
+| `MCP_DANGEROUSLY_ALLOW_DCR`        | Enable Dynamic Client Registration (`true`/`false`)         | Dev only (see below)       |
+| `MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC` | Escape hatch to allow DCR on non-loopback binds             | Never, unless you mean it  |
 
 **Client ID validation rules:**
 
@@ -153,4 +155,14 @@ When auth is enabled, the server exposes these OAuth 2.1 endpoints:
 - `POST /token` — Token exchange (requires client_secret)
 - `POST /revoke` — Token revocation
 
-Dynamic client registration is **disabled** — only the pre-configured client (from `MCP_CLIENT_ID` + `MCP_CLIENT_SECRET`) can authenticate. This prevents anyone who knows the server URL from self-registering and bypassing auth.
+Dynamic client registration is **disabled by default** — only the pre-configured client (from `MCP_CLIENT_ID` + `MCP_CLIENT_SECRET`) can authenticate. This prevents anyone who knows the server URL from self-registering and bypassing auth.
+
+#### Cursor / Windsurf compatibility (dev only)
+
+Cursor and Windsurf only support MCP servers that expose OAuth 2.0 Dynamic Client Registration (RFC 7591). To let them connect, set `MCP_DANGEROUSLY_ALLOW_DCR=true`. The server will then advertise a `/register` endpoint and accept ad-hoc client registrations (kept in an in-memory FIFO store, capped at 100 entries).
+
+`MCP_CLIENT_ID` and `MCP_CLIENT_SECRET` are still required — DCR augments the pre-configured client, it does not replace it. If you are only running Cursor locally you can use any valid values for them; they simply remain unused.
+
+**This is dev-only.** With DCR enabled alongside the server's auto-approve authorization flow, any client that can reach the server can register itself and obtain a token. To prevent accidental exposure the server refuses to start when `MCP_DANGEROUSLY_ALLOW_DCR=true` and `HOST` is not loopback (`127.0.0.1`, `localhost`, or `::1`). If you genuinely need DCR on a non-loopback bind (e.g., inside a trusted private network), also set `MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true`.
+
+For production with Claude.ai, keep DCR disabled and use the pre-configured `MCP_CLIENT_ID` / `MCP_CLIENT_SECRET`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-mcp",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Model Context Protocol (MCP) server for OpenClaw AI assistant integration",
   "author": "Tomáš Grasl <https://www.tomasgrasl.cz/>",
   "license": "MIT",

--- a/src/__tests__/auth/oauth.test.ts
+++ b/src/__tests__/auth/oauth.test.ts
@@ -16,9 +16,76 @@ describe('OpenClawClientsStore', () => {
     expect(client).toBeUndefined();
   });
 
-  it('does not support dynamic registration', () => {
+  it('does not support dynamic registration by default', () => {
     const store = new OpenClawClientsStore({});
     expect((store as any).registerClient).toBeUndefined();
+  });
+
+  it('exposes registerClient when allowDynamicRegistration is true', async () => {
+    const store = new OpenClawClientsStore({ allowDynamicRegistration: true });
+    expect(typeof (store as any).registerClient).toBe('function');
+
+    const dynamic = {
+      client_id: 'dyn-id',
+      client_secret: 'dyn-secret',
+      redirect_uris: ['http://localhost/cb'],
+      token_endpoint_auth_method: 'client_secret_post',
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      client_name: 'Cursor',
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    };
+    const registered = await (store as any).registerClient(dynamic);
+    expect(registered.client_id).toBe('dyn-id');
+
+    const fetched = await store.getClient('dyn-id');
+    expect(fetched?.client_secret).toBe('dyn-secret');
+  });
+
+  it('evicts oldest dynamically registered client when cap is exceeded', async () => {
+    const store = new OpenClawClientsStore({ allowDynamicRegistration: true });
+    const register = (store as any).registerClient.bind(store);
+    const makeClient = (id: string) => ({
+      client_id: id,
+      client_secret: `secret-${id}`,
+      redirect_uris: ['http://localhost/cb'],
+      token_endpoint_auth_method: 'client_secret_post',
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      client_name: 'Test',
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    });
+
+    // Fill past the cap (100) — the first insert should be evicted.
+    for (let i = 0; i < 101; i++) {
+      await register(makeClient(`client-${i}`));
+    }
+
+    expect(await store.getClient('client-0')).toBeUndefined();
+    expect((await store.getClient('client-100'))?.client_id).toBe('client-100');
+  });
+
+  it('serves both pre-configured and dynamically registered clients', async () => {
+    const store = new OpenClawClientsStore({
+      clientId: 'preset',
+      clientSecret: 'preset-secret',
+      allowDynamicRegistration: true,
+    });
+
+    await (store as any).registerClient({
+      client_id: 'dyn-id',
+      client_secret: 'dyn-secret',
+      redirect_uris: ['http://localhost/cb'],
+      token_endpoint_auth_method: 'client_secret_post',
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      client_name: 'Cursor',
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    });
+
+    expect((await store.getClient('preset'))?.client_id).toBe('preset');
+    expect((await store.getClient('dyn-id'))?.client_id).toBe('dyn-id');
+    expect(await store.getClient('unknown')).toBeUndefined();
   });
 
   it('works with no pre-configured client', async () => {
@@ -209,5 +276,31 @@ describe('OpenClawAuthProvider', () => {
     await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow(
       'Invalid or expired token'
     );
+  });
+
+  it('does not revoke tokens owned by another client', async () => {
+    const provider = new OpenClawAuthProvider(config);
+    const client = (await provider.clientsStore.getClient('test-client'))!;
+
+    let redirectUrl = '';
+    const mockRes = {
+      redirect: (url: string) => {
+        redirectUrl = url;
+      },
+    };
+    await provider.authorize(
+      client,
+      { codeChallenge: 'ch', redirectUri: 'http://localhost/cb' },
+      mockRes as any
+    );
+    const code = new URL(redirectUrl).searchParams.get('code')!;
+    const tokens = await provider.exchangeAuthorizationCode(client, code);
+
+    const attacker = { ...client, client_id: 'attacker' };
+    await provider.revokeToken(attacker, { token: tokens.access_token });
+
+    // Token must still be valid — attacker is not allowed to revoke it.
+    const info = await provider.verifyAccessToken(tokens.access_token);
+    expect(info.clientId).toBe('test-client');
   });
 });

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -6,9 +6,10 @@
  * Claude.ai and MCP Inspector can use to authenticate.
  *
  * Pre-configured client credentials come from MCP_CLIENT_ID + MCP_CLIENT_SECRET
- * env vars. Dynamic client registration is disabled — only the pre-configured
- * client can authenticate. The pre-configured client accepts any redirect_uri
- * (it's added to the allowlist on first use by the SDK authorize handler).
+ * env vars. By default, dynamic client registration (DCR) is disabled — only
+ * the pre-configured client can authenticate. Setting MCP_DANGEROUSLY_ALLOW_DCR=true
+ * opts into DCR so clients like Cursor and Windsurf, which require DCR, can
+ * connect. That mode is intended for local development only.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -38,6 +39,13 @@ export interface AuthProviderConfig {
   clientSecret?: string;
   /** Allowed redirect URIs. When empty/undefined, any redirect_uri is accepted (with a warning). */
   redirectUris?: string[];
+  /**
+   * Enable OAuth 2.0 Dynamic Client Registration (RFC 7591).
+   * Required for clients like Cursor / Windsurf. Dev-only — auto-registered
+   * clients combined with auto-approve mean anyone who can reach the server
+   * can obtain a token.
+   */
+  allowDynamicRegistration?: boolean;
 }
 
 // --- Clients Store ---
@@ -74,11 +82,32 @@ const ALLOW_ANY_REDIRECT: string[] = new Proxy([] as string[], {
 });
 
 /**
- * In-memory clients store. Only the pre-configured client from env vars is allowed.
- * Dynamic client registration is intentionally disabled to prevent unauthorized access.
+ * In-memory clients store.
+ *
+ * Always serves the pre-configured client from env vars. When
+ * `allowDynamicRegistration` is true, the `registerClient` method is
+ * exposed so the SDK advertises `/register` in OAuth metadata and accepts
+ * RFC 7591 dynamic registration requests (kept in memory until restart).
  */
+/**
+ * Cap on dynamically registered clients to avoid unbounded memory growth when
+ * DCR is left enabled in a long-running dev session. FIFO eviction keeps the
+ * store bounded; the MCP SDK's per-IP rate limit (20/hr) is the first line of
+ * defense, this cap is a backstop.
+ */
+const MAX_DYNAMIC_CLIENTS = 100;
+
 export class OpenClawClientsStore implements OAuthRegisteredClientsStore {
   private client: OAuthClientInformationFull | undefined;
+  private dynamicClients = new Map<string, OAuthClientInformationFull>();
+
+  // Assigned conditionally in the constructor. The MCP SDK probes
+  // `clientsStore.registerClient` at router-setup time and only advertises
+  // `/register` when the property is defined, so we must NOT define a no-op
+  // method on the prototype — it has to be instance-level and gated on config.
+  registerClient?: (
+    client: OAuthClientInformationFull
+  ) => OAuthClientInformationFull | Promise<OAuthClientInformationFull>;
 
   constructor(config: AuthProviderConfig) {
     if (config.clientId && config.clientSecret) {
@@ -98,18 +127,29 @@ export class OpenClawClientsStore implements OAuthRegisteredClientsStore {
         client_id_issued_at: Math.floor(Date.now() / 1000),
       };
     }
+
+    if (config.allowDynamicRegistration) {
+      this.registerClient = (client) => {
+        // FIFO eviction when the cap is reached. Map iteration order is
+        // insertion order, so the first key is the oldest entry.
+        if (this.dynamicClients.size >= MAX_DYNAMIC_CLIENTS) {
+          const oldestKey = this.dynamicClients.keys().next().value;
+          if (oldestKey !== undefined) {
+            this.dynamicClients.delete(oldestKey);
+          }
+        }
+        this.dynamicClients.set(client.client_id, client);
+        return client;
+      };
+    }
   }
 
   async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
     if (this.client && this.client.client_id === clientId) {
       return this.client;
     }
-    return undefined;
+    return this.dynamicClients.get(clientId);
   }
-
-  // No registerClient — dynamic client registration is intentionally disabled.
-  // Only the pre-configured client from MCP_CLIENT_ID + MCP_CLIENT_SECRET can authenticate.
-  // This prevents anyone who knows the server URL from self-registering and bypassing auth.
 }
 
 // --- Auth Provider ---
@@ -309,10 +349,21 @@ export class OpenClawAuthProvider implements OAuthServerProvider {
   }
 
   async revokeToken(
-    _client: OAuthClientInformationFull,
+    client: OAuthClientInformationFull,
     request: OAuthTokenRevocationRequest
   ): Promise<void> {
-    this.tokens.delete(request.token);
-    this.refreshTokens.delete(request.token);
+    // RFC 7009: the token is only revoked if it was issued to the requesting
+    // client. Without this check, any authenticated client could revoke any
+    // other client's tokens — which becomes exploitable once DCR lets strangers
+    // obtain a valid client_id/secret pair.
+    const tokenData = this.tokens.get(request.token);
+    if (tokenData && tokenData.clientId === client.client_id) {
+      this.tokens.delete(request.token);
+    }
+
+    const refreshData = this.refreshTokens.get(request.token);
+    if (refreshData && refreshData.clientId === client.client_id) {
+      this.refreshTokens.delete(request.token);
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ export interface CliArgs {
   clientSecret: string | undefined;
   issuerUrl: string | undefined;
   redirectUris: string[] | undefined;
+  allowDcr: boolean;
   instances: InstanceConfig[];
 }
 
@@ -93,6 +94,12 @@ export function parseArguments(version: string): CliArgs {
       description: 'Allowed OAuth redirect URIs (comma-separated)',
       default: process.env.MCP_REDIRECT_URIS || undefined,
     })
+    .option('allow-dcr', {
+      type: 'boolean',
+      description:
+        'Allow OAuth Dynamic Client Registration (Cursor/Windsurf compatibility, dev-only)',
+      default: process.env.MCP_DANGEROUSLY_ALLOW_DCR === 'true',
+    })
     .help()
     .parseSync();
 
@@ -160,6 +167,7 @@ export function parseArguments(version: string): CliArgs {
           .map((s) => s.trim())
           .filter(Boolean)
       : undefined,
+    allowDcr: argv['allow-dcr'] as boolean,
     instances,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ async function main() {
         clientId: args.clientId,
         clientSecret: args.clientSecret,
         redirectUris: args.redirectUris,
+        allowDynamicRegistration: args.allowDcr,
       };
       log(`OAuth client ID: ${args.clientId}`);
       if (!args.redirectUris || args.redirectUris.length === 0) {
@@ -82,6 +83,34 @@ async function main() {
           'WARNING: MCP_REDIRECT_URIS not set — any redirect_uri will be accepted. ' +
             'Set MCP_REDIRECT_URIS for production.'
         );
+      }
+      if (args.allowDcr) {
+        // DCR + auto-approve = any reachable client can self-register and obtain
+        // a bearer token without user interaction. Refuse to bind non-loopback
+        // hosts unless the operator explicitly opts in via the escape hatch.
+        const isLoopback =
+          args.host === '127.0.0.1' || args.host === 'localhost' || args.host === '::1';
+        const publicOptIn = process.env.MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC === 'true';
+        if (!isLoopback && !publicOptIn) {
+          logError(
+            `MCP_DANGEROUSLY_ALLOW_DCR=true is set but HOST="${args.host}" is not loopback. ` +
+              'Dynamic Client Registration combined with a publicly reachable bind allows ' +
+              'anyone on the network to obtain a token. Bind to 127.0.0.1, or set ' +
+              'MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true to override. Refusing to start.'
+          );
+          process.exit(1);
+        }
+        log(
+          'WARNING: MCP_DANGEROUSLY_ALLOW_DCR is enabled — OAuth Dynamic Client Registration is open. ' +
+            'Any client that can reach this server may self-register and obtain tokens. ' +
+            'Use for local development only.'
+        );
+        if (publicOptIn) {
+          log(
+            'WARNING: MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true — DCR is exposed on a non-loopback bind. ' +
+              'You have explicitly accepted the risk.'
+          );
+        }
       }
     } else if (args.authEnabled && !args.clientId) {
       logError('AUTH_ENABLED=true but MCP_CLIENT_ID is not set. Refusing to start without auth.');


### PR DESCRIPTION
## Summary

- Adds an opt-in `MCP_DANGEROUSLY_ALLOW_DCR` env var (dev-only) that enables OAuth 2.0 Dynamic Client Registration (RFC 7591), so Cursor and Windsurf can connect to the MCP bridge.
- Bundles multiple guard rails (loopback-only bind, FIFO cap on registered clients, loud startup warnings, `DANGEROUSLY` name) so the flag cannot be turned on by accident.
- Tightens `revokeToken` to verify the token belongs to the requesting client (RFC 7009), which becomes exploitable once DCR lets strangers hold a valid `client_id`/`client_secret` pair.

Fixes #24.

## Why

`wangzihe843-hash` reported that Cursor fails to connect with `Incompatible auth server: does not support dynamic client registration`. The store previously hard-disabled DCR for security. We keep that default but allow an explicit dev-only opt-in.

## Changes

- `src/auth/provider.ts` — conditional instance-level `registerClient`, FIFO-bounded `dynamicClients` map (cap 100), stricter `revokeToken`.
- `src/cli.ts` — `--allow-dcr` flag / `MCP_DANGEROUSLY_ALLOW_DCR` env var.
- `src/index.ts` — loopback-only guard (override via `MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true`), startup warnings.
- `.env.example`, `docs/configuration.md` — dev-only docs + Cursor/Windsurf compatibility section.
- `src/__tests__/auth/oauth.test.ts` — 4 new tests (DCR toggle, cap eviction, coexistence with pre-configured client, revoke ownership).
- `package.json` / `package-lock.json` — bump to `1.4.0`.

## Security notes

DCR + the existing auto-approve authorize flow = any reachable client can obtain a token. Mitigations:

1. Flag is opt-in and named `DANGEROUSLY`.
2. Server refuses to start with DCR on and a non-loopback `HOST` unless `MCP_DANGEROUSLY_ALLOW_DCR_PUBLIC=true` is also set.
3. Documentation is explicit that this is dev-only and must stay off in production.

Known gap (see review notes on the branch): the loopback check only inspects `HOST`. A reverse-proxy setup with `HOST=127.0.0.1` + public `MCP_ISSUER_URL` can expose DCR without tripping the guard. Accepted for this iteration — requires explicit opt-in of `DANGEROUSLY` flag + running behind a reverse proxy. Docs call this out.

## Test plan

- [x] `npm run test:run` — 142/142 passing (was 140, added 2 DCR tests + 1 revoke ownership test + 1 cap eviction test)
- [x] `npm run lint` — clean
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `./node_modules/.bin/tsup` — builds (54 KB bundle)
- [ ] Manual: set `AUTH_ENABLED=true MCP_CLIENT_ID=openclaw MCP_CLIENT_SECRET=<32+ hex> MCP_DANGEROUSLY_ALLOW_DCR=true HOST=127.0.0.1` → connect Cursor → verify it can complete OAuth flow via DCR
- [ ] Manual: same setup with `HOST=0.0.0.0` → server exits with the expected error message
- [ ] Manual: verify `AUTH_ENABLED=false` path (no OAuth router, no `/register`) is unaffected