### PR TITLE
feat: publish to MCP Registry on release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,44 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Sync server.json version with release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "Publishing version: $VERSION"
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = '$VERSION';
+            for (const p of s.packages || []) p.version = '$VERSION';
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.freema/openclaw-mcp -->
+
 # OpenClaw MCP Server
 
 [![npm version](https://badge.fury.io/js/openclaw-mcp.svg)](https://www.npmjs.com/package/openclaw-mcp)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.freema/openclaw-mcp",
+  "description": "Model Context Protocol (MCP) server for OpenClaw AI assistant integration — bridges Claude Desktop and Claude.ai with self-hosted OpenClaw via OAuth 2.1.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/freema/openclaw-mcp",
+    "source": "github"
+  },
+  "version": "1.4.0",
+  "websiteUrl": "https://openclaw-mcp.cloud",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "openclaw-mcp",
+      "version": "1.4.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "OPENCLAW_URL",
+          "description": "URL of your OpenClaw gateway",
+          "default": "http://127.0.0.1:18789",
+          "isRequired": true
+        },
+        {
+          "name": "OPENCLAW_GATEWAY_TOKEN",
+          "description": "Bearer token for OpenClaw gateway authentication",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "OPENCLAW_MODEL",
+          "description": "Model name for chat completions (e.g. 'openclaw' or 'openclaw/<agentId>')",
+          "default": "openclaw",
+          "isRequired": false
+        },
+        {
+          "name": "OPENCLAW_TIMEOUT_MS",
+          "description": "Request timeout in milliseconds",
+          "default": "120000",
+          "isRequired": false
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "freema/openclaw-mcp",
+      "version": "1.4.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "OPENCLAW_URL",
+          "description": "URL of your OpenClaw gateway",
+          "default": "http://127.0.0.1:18789",
+          "isRequired": true
+        },
+        {
+          "name": "OPENCLAW_GATEWAY_TOKEN",
+          "description": "Bearer token for OpenClaw gateway authentication",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "OPENCLAW_MODEL",
+          "description": "Model name for chat completions",
+          "default": "openclaw",
+          "isRequired": false
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://openclaw-mcp.cloud/sse"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` at repo root with namespace `io.github.freema/openclaw-mcp`, describing both npm (`openclaw-mcp`) and OCI (`ghcr.io/freema/openclaw-mcp`) distributions plus the `openclaw-mcp.cloud` SSE remote.
- Adds the `<!-- mcp-name: io.github.freema/openclaw-mcp -->` ownership marker to README so `mcp-publisher` can verify the namespace.
- Adds `.github/workflows/publish-mcp-registry.yml` that runs on `release: published` (and `workflow_dispatch`), syncs the version from the release tag into `server.json`, logs in via GitHub OIDC, and publishes via `mcp-publisher`.

No tokens or secrets needed — `io.github.freema/*` is authenticated through repo OIDC.

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` once merged to verify the publish flow end-to-end.
- [ ] Confirm entry appears at https://registry.modelcontextprotocol.io after first run.
- [ ] On next tagged release, confirm the action picks up the new version into `server.json` automatically.
- [ ] (Follow-up) Open issue in `github/mcp-registry` requesting inclusion in the GitHub-curated subset.

## Notes
- `version` in `server.json` is currently `1.4.0` to match `package.json`; the workflow overrides it from the release tag at publish time.
- OCI package version assumes the GHCR image is tagged with the concrete release version (not just `latest`) — verify the release pipeline does this before the first run.
- If `openclaw-mcp.cloud/sse` is not yet a stable production endpoint, drop the `remotes` block before merging.