### PR TITLE
docs: add OpenClaw plugin bridge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ See [Installation Guide](docs/installation.md) for details.
 | `openclaw_task_list` | List all tasks with filtering |
 | `openclaw_task_cancel` | Cancel a pending task |
 
+## Using OpenClaw Plugins Through the Bridge
+
+This MCP server sends Claude.ai or Claude Desktop requests to your OpenClaw
+gateway, so OpenClaw-native plugins should be installed in OpenClaw itself.
+For X/Twitter automation, install TweetClaw in the OpenClaw workspace:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Then ask Claude to delegate X/Twitter work to OpenClaw. TweetClaw can search
+tweets, search tweet replies, export followers, inspect users, manage media,
+send direct messages, monitor tweets, create webhooks, run giveaway draws, and
+request reviewed post tweets or post tweet replies through OpenClaw approval
+prompts.
+
+Keep TweetClaw credentials in OpenClaw plugin config, not in Claude.ai, Claude
+Desktop, or this MCP bridge config. See the
+[TweetClaw README](https://github.com/Xquik-dev/tweetclaw#readme) for setup and
+safety details.
+
 ## Multi-Instance Mode
 
 Orchestrate multiple OpenClaw gateways from a single MCP server. One bridge, many claws — route requests to prod, staging, dev, or whatever you name them (lobster-supreme and the-claw-abides are perfectly valid names).
@@ -281,4 +302,4 @@ Created by [Tomáš Grasl](https://www.tomasgrasl.cz/)
 ## Related Projects
 
 - [OpenClaw](https://github.com/openclaw/openclaw) — The AI assistant this MCP connects to
-- [MCP Specification](https://spec.modelcontextprotocol.io/) — Model Context Protocol docs
+- [MCP Specification](https://modelcontextprotocol.io/specification) - Model Context Protocol docs


### PR DESCRIPTION
## Summary

- Add a README section for using OpenClaw-native plugins through this MCP bridge.
- Document TweetClaw as a concrete X/Twitter automation example for bridged OpenClaw sessions.
- Update the MCP Specification link to the current official specification URL.

## Validation

- Searched the repo and all open and closed issues and PRs for TweetClaw, Xquik, @xquik/tweetclaw, Xquik-dev/tweetclaw, npmjs.com/package/@xquik/tweetclaw, and x-twitter-scraper. No duplicates found.
- Checked README external and local links after stripping code examples: 16 external links, 8 local links, 0 failures.
- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm view @xquik/tweetclaw version --silent` returned `1.6.31`
