### PR TITLE
fix(sse): TRUST_PROXY env / --trust-proxy CLI for reverse-proxy setups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ HOST=0.0.0.0
 # Also enabled when NODE_ENV=development
 DEBUG=false
 
+# Express "trust proxy" setting — REQUIRED when running behind a reverse proxy
+# (Caddy, nginx, Traefik, Cloudflare Tunnel, etc.) that sets X-Forwarded-For.
+# Without it, express-rate-limit (used by the MCP SDK auth handlers) crashes
+# /token with ERR_ERL_UNEXPECTED_X_FORWARDED_FOR and OAuth breaks.
+# Values:
+#   (unset)     - Express default, do not trust any proxy
+#   1           - Trust one hop (typical for a single reverse proxy)
+#   true        - Trust all proxies (only on a private network)
+#   loopback    - Trust 127.0.0.1, ::1
+#   10.0.0.0/8  - Trust a specific CIDR / IP
+# TRUST_PROXY=1
+
 # =============================================================================
 # CORS Configuration (SSE transport only)
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ services:
       - MCP_CLIENT_ID=openclaw
       - MCP_CLIENT_SECRET=${MCP_CLIENT_SECRET}
       - MCP_ISSUER_URL=${MCP_ISSUER_URL:-}
+      - TRUST_PROXY=1
       - CORS_ORIGINS=https://claude.ai
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -110,7 +111,9 @@ AUTH_ENABLED=true MCP_CLIENT_ID=openclaw MCP_CLIENT_SECRET=your-secret \
   npx openclaw-mcp --transport sse --port 3000
 ```
 
-> **Important:** When running behind a reverse proxy (Caddy, nginx, etc.), you **must** set `MCP_ISSUER_URL` (or `--issuer-url`) to your public HTTPS URL. Without this, OAuth metadata will advertise `http://localhost:3000` and clients will fail to authenticate.
+> **Important:** When running behind a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel, etc.) you **must** set:
+> - `MCP_ISSUER_URL` (or `--issuer-url`) to your public HTTPS URL — otherwise OAuth metadata advertises `http://localhost:3000` and clients fail to authenticate.
+> - `TRUST_PROXY=1` (or `--trust-proxy 1`) — otherwise `express-rate-limit` rejects the proxy's `X-Forwarded-For` header and `/token` crashes with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.
 
 See [Installation Guide](docs/installation.md) for details.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,11 +102,24 @@ services:
 
 ### Server Settings (SSE transport)
 
-| Variable | Description          | Default   |
-| -------- | -------------------- | --------- |
-| `PORT`   | SSE server port      | `3000`    |
-| `HOST`   | SSE server host      | `0.0.0.0` |
-| `DEBUG`  | Enable debug logging | `false`   |
+| Variable      | Description                                                       | Default                  |
+| ------------- | ----------------------------------------------------------------- | ------------------------ |
+| `PORT`        | SSE server port                                                   | `3000`                   |
+| `HOST`        | SSE server host                                                   | `0.0.0.0`                |
+| `DEBUG`       | Enable debug logging                                              | `false`                  |
+| `TRUST_PROXY` | Express `trust proxy` setting (required behind a reverse proxy)   | (unset — trust nothing)  |
+
+**`TRUST_PROXY` values:**
+
+| Value          | Meaning                                                                        |
+| -------------- | ------------------------------------------------------------------------------ |
+| (unset)        | Express default — do not trust any proxy                                       |
+| `1`            | Trust one hop — typical when there is a single reverse proxy in front          |
+| `true`         | Trust every proxy — only safe on a fully private network                       |
+| `loopback`     | Trust `127.0.0.1` and `::1`                                                    |
+| `10.0.0.0/8`   | Trust a specific IP or CIDR range                                              |
+
+When `TRUST_PROXY` is unset and a reverse proxy injects an `X-Forwarded-For` header, the MCP SDK's `/token` handler crashes with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` and OAuth fails. Set this whenever the server is behind Caddy, nginx, Traefik, Cloudflare Tunnel, ngrok, or any other proxy.
 
 ### CORS Configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,6 +78,7 @@ docker compose up -d
 - [ ] `MCP_CLIENT_ID` is valid (3–64 chars, alphanumeric/dashes/underscores)
 - [ ] `MCP_CLIENT_SECRET` generated securely (`openssl rand -hex 32`, min 32 chars)
 - [ ] `MCP_ISSUER_URL` set to public HTTPS URL (when behind reverse proxy)
+- [ ] `TRUST_PROXY` set to the right hop count / CIDR (when behind reverse proxy)
 - [ ] `MCP_REDIRECT_URIS` restricted to known callback URLs
 - [ ] CORS restricted to known origins (`CORS_ORIGINS=https://claude.ai`)
 - [ ] `OPENCLAW_GATEWAY_TOKEN` set for gateway authentication
@@ -88,7 +89,9 @@ docker compose up -d
 
 The MCP bridge must be served over HTTPS for production use. Use a reverse proxy that handles TLS termination.
 
-> **Important:** You **must** set `MCP_ISSUER_URL` to your public HTTPS URL. Without this, OAuth metadata endpoints will advertise `http://localhost:3000` and MCP clients (including Claude.ai) will fail to authenticate with the error: `Protected resource http://localhost:3000/mcp does not match expected https://your-domain.com/mcp`.
+> **Important:** When running behind a reverse proxy you **must** set both:
+> - `MCP_ISSUER_URL` to your public HTTPS URL — otherwise OAuth metadata endpoints advertise `http://localhost:3000` and MCP clients (including Claude.ai) fail to authenticate with `Protected resource http://localhost:3000/mcp does not match expected https://your-domain.com/mcp`.
+> - `TRUST_PROXY=1` so Express trusts the proxy's `X-Forwarded-For` header — otherwise `express-rate-limit` (used by the MCP SDK auth handlers) crashes `/token` with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.
 
 ### Caddy (recommended)
 
@@ -122,6 +125,7 @@ services:
       - "3000"
     environment:
       - MCP_ISSUER_URL=https://mcp.your-domain.com
+      - TRUST_PROXY=1
       # ... other env vars
 
 volumes:
@@ -200,6 +204,10 @@ You're running behind a reverse proxy but haven't set `MCP_ISSUER_URL`. The OAut
 ### `POST /` or `GET /` returns 404 after OAuth succeeds
 
 Your Claude.ai connector URL is missing the `/mcp` path. The MCP Streamable HTTP transport is mounted at `/mcp`, not at the server root (which is intentional — root is reserved for `/health`, `/.well-known/*`, OAuth endpoints, and the legacy SSE transport). Update the connector URL in Claude.ai to end with `/mcp`, e.g. `https://mcp.your-domain.com/mcp`.
+
+### `ValidationError: ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on `/token`
+
+The server is behind a reverse proxy that sets `X-Forwarded-For`, but Express's `trust proxy` is left at its default (`false`). The MCP SDK's OAuth handlers use `express-rate-limit`, which refuses to read the forwarded header in that configuration and crashes the request. Set `TRUST_PROXY=1` (single proxy in front) or `--trust-proxy 1`. Use a higher hop count, a CIDR/IP, or a keyword (`loopback`, `linklocal`, `uniquelocal`) for more complex topologies — see [Server Settings](configuration.md#server-settings-sse-transport).
 
 ### `fetch failed` / MCP bridge can't reach gateway
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,8 +101,11 @@ Options:
   --client-secret     MCP OAuth client secret  [env: MCP_CLIENT_SECRET]
   --issuer-url        OAuth issuer URL         [env: MCP_ISSUER_URL]
   --redirect-uris     Allowed redirect URIs    [env: MCP_REDIRECT_URIS]
+  --trust-proxy       Express trust proxy      [env: TRUST_PROXY]
   --version           Show version number
   --help              Show help
 ```
 
 > **Note:** `--issuer-url` is required when running behind a reverse proxy (Caddy, nginx, etc.) so that OAuth metadata endpoints return the correct public HTTPS URL instead of `http://localhost:3000`.
+
+> **Note:** `--trust-proxy` (or `TRUST_PROXY`) is also required when running behind a reverse proxy. Use `1` for a single proxy, `true` on a fully private network, or a CIDR/keyword (`loopback`, `linklocal`, `uniquelocal`) for more specific setups. Without it, `/token` crashes with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.

--- a/src/__tests__/server/sse.test.ts
+++ b/src/__tests__/server/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadCorsConfig, isOriginAllowed } from '../../server/sse.js';
+import { loadCorsConfig, isOriginAllowed, parseTrustProxy } from '../../server/sse.js';
 
 describe('loadCorsConfig', () => {
   beforeEach(() => {
@@ -74,5 +74,42 @@ describe('isOriginAllowed', () => {
   it('matches with protocol prefix', () => {
     expect(isOriginAllowed('https://example.com', ['example.com'])).toBe(true);
     expect(isOriginAllowed('http://example.com', ['example.com'])).toBe(true);
+  });
+});
+
+describe('parseTrustProxy', () => {
+  it('returns undefined for unset input', () => {
+    expect(parseTrustProxy(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseTrustProxy('')).toBeUndefined();
+    expect(parseTrustProxy('   ')).toBeUndefined();
+  });
+
+  it('parses "true" / "false" (case-insensitive) into booleans', () => {
+    expect(parseTrustProxy('true')).toBe(true);
+    expect(parseTrustProxy('TRUE')).toBe(true);
+    expect(parseTrustProxy('false')).toBe(false);
+    expect(parseTrustProxy('False')).toBe(false);
+  });
+
+  it('parses pure-digit strings into numbers (hop count)', () => {
+    expect(parseTrustProxy('0')).toBe(0);
+    expect(parseTrustProxy('1')).toBe(1);
+    expect(parseTrustProxy('2')).toBe(2);
+  });
+
+  it('passes CIDR / IP / keyword strings through untouched', () => {
+    expect(parseTrustProxy('loopback')).toBe('loopback');
+    expect(parseTrustProxy('linklocal')).toBe('linklocal');
+    expect(parseTrustProxy('uniquelocal')).toBe('uniquelocal');
+    expect(parseTrustProxy('10.0.0.0/8')).toBe('10.0.0.0/8');
+    expect(parseTrustProxy('192.168.1.1')).toBe('192.168.1.1');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseTrustProxy('  1  ')).toBe(1);
+    expect(parseTrustProxy('  true  ')).toBe(true);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ export interface CliArgs {
   issuerUrl: string | undefined;
   redirectUris: string[] | undefined;
   allowDcr: boolean;
+  trustProxy: string | undefined;
   instances: InstanceConfig[];
 }
 
@@ -100,6 +101,12 @@ export function parseArguments(version: string): CliArgs {
         'Allow OAuth Dynamic Client Registration (Cursor/Windsurf compatibility, dev-only)',
       default: process.env.MCP_DANGEROUSLY_ALLOW_DCR === 'true',
     })
+    .option('trust-proxy', {
+      type: 'string',
+      description:
+        'Express trust proxy setting when behind a reverse proxy (e.g. "1", "true", or a CIDR)',
+      default: process.env.TRUST_PROXY || undefined,
+    })
     .help()
     .parseSync();
 
@@ -168,6 +175,7 @@ export function parseArguments(version: string): CliArgs {
           .filter(Boolean)
       : undefined,
     allowDcr: argv['allow-dcr'] as boolean,
+    trustProxy: argv['trust-proxy'] as string | undefined,
     instances,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { log, logError, setDebugEnabled } from './utils/logger.js';
 import { parseArguments } from './cli.js';
 import { InstanceRegistry } from './openclaw/registry.js';
 import { createMcpServer, type ToolRegistrationDeps } from './server/tools-registration.js';
-import { createSSEServer, type SSEServerConfig } from './server/sse.js';
+import { createSSEServer, parseTrustProxy, type SSEServerConfig } from './server/sse.js';
 
 // Parse CLI arguments
 const args = parseArguments(SERVER_VERSION);
@@ -51,6 +51,7 @@ async function main() {
       port: args.port,
       host: args.host,
       issuerUrl: args.issuerUrl,
+      trustProxy: parseTrustProxy(args.trustProxy),
     };
 
     // Enable OAuth when auth flag is set and client credentials are provided

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -31,8 +31,39 @@ export interface SSEServerConfig {
   host: string;
   /** Override the OAuth issuer URL (e.g., https://mcp.example.com behind a reverse proxy) */
   issuerUrl?: string;
+  /**
+   * Express `trust proxy` setting. Required when behind a reverse proxy that
+   * sets `X-Forwarded-For` — otherwise `express-rate-limit` (used by the MCP
+   * SDK auth handlers) throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on `/token`.
+   * Accepts `true` / `false`, a hop count (e.g. `1`), or an IP/CIDR string or
+   * keyword (`loopback`, `linklocal`, `uniquelocal`). Undefined leaves the
+   * Express default (`false`) untouched.
+   */
+  trustProxy?: boolean | number | string;
   /** Auth is enabled when authConfig is provided */
   authConfig?: AuthProviderConfig;
+}
+
+/**
+ * Parse the TRUST_PROXY env var / --trust-proxy CLI flag into an
+ * Express-compatible value. Returns `undefined` when the input is empty so
+ * callers can skip `app.set('trust proxy', …)` entirely.
+ */
+export function parseTrustProxy(value: string | undefined): boolean | number | string | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  if (/^\d+$/.test(trimmed)) {
+    return parseInt(trimmed, 10);
+  }
+  return trimmed;
 }
 
 // --- CORS helpers ---
@@ -110,6 +141,14 @@ export async function createSSEServer(
 
   // Express app from SDK (includes JSON body parser + DNS rebinding protection)
   const app = createMcpExpressApp({ host: config.host });
+
+  // Configure Express `trust proxy` when running behind a reverse proxy.
+  // Without this, `express-rate-limit` (used by the MCP SDK auth handlers)
+  // crashes /token with ERR_ERL_UNEXPECTED_X_FORWARDED_FOR.
+  if (config.trustProxy !== undefined) {
+    app.set('trust proxy', config.trustProxy);
+    log(`Trust proxy: ${JSON.stringify(config.trustProxy)}`);
+  }
 
   // --- CORS middleware (before auth so preflight works) ---
   app.use((req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Summary

- Adds a `TRUST_PROXY` env var and matching `--trust-proxy` CLI flag that map to Express's `app.set('trust proxy', …)`.
- Without this, the MCP SDK's OAuth handlers crash `/token` with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when the bridge runs behind any reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel, ngrok, …) that sets `X-Forwarded-For`. That breaks the entire OAuth flow.
- Accepts `true` / `false`, a hop count (`1`, `2`, …), or an IP/CIDR string or keyword (`loopback`, `linklocal`, `uniquelocal`).
- Default is unset → Express default (`false`) is left untouched, so existing direct-bind deployments are unaffected.

## Why

The MCP SDK installs `mcpAuthRouter` which wraps `authorize`, `token`, `register`, and `revoke` in `express-rate-limit`. `express-rate-limit` refuses to read `X-Forwarded-For` unless Express's `trust proxy` is configured, and crashes the request rather than silently using the proxy IP. There is no way to opt out from the SDK side, so the bridge has to configure Express.

Reported by @Kakuzen93 in #30 (bug 1) — bug 2 in that report was a `/mcp` path misconfiguration in the Claude.ai connector URL, which was already addressed by [1553e1c](https://github.com/freema/openclaw-mcp/commit/1553e1c) (README + troubleshooting note clarifying that the connector URL must end with `/mcp`).

## Changes

- `src/server/sse.ts` — new `trustProxy` field on `SSEServerConfig`, calls `app.set('trust proxy', …)` immediately after the Express app is created. New exported `parseTrustProxy()` helper.
- `src/cli.ts` — `--trust-proxy` flag, reads `TRUST_PROXY` env, threaded through `CliArgs`.
- `src/index.ts` — wires `args.trustProxy` into `sseConfig` via `parseTrustProxy()`.
- `src/__tests__/server/sse.test.ts` — covers boolean / hop-count / CIDR / keyword / whitespace cases.
- `.env.example`, `README.md`, `docs/configuration.md`, `docs/deployment.md`, `docs/installation.md` — documents the new var, adds it to the Docker quick-start, security checklist, reverse-proxy section, troubleshooting entry, and CLI options.

## Test plan

- [x] `npm run lint`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `npm run test:run` — 148/148 passing (10 new tests for `parseTrustProxy`)
- [x] `./node_modules/.bin/tsup` — build succeeds
- [ ] Manual smoke test behind Cloudflare Tunnel / Caddy with `TRUST_PROXY=1` confirming `/token` no longer crashes (to do during release verification)

Closes #30 once released.