### PR TITLE
fix(auth): allow-any redirect fallback broken by MCP SDK ≥1.29

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,8 +78,10 @@ MCP_CLIENT_SECRET=
 # MCP_ISSUER_URL=https://mcp.example.com
 
 # Allowed OAuth redirect URIs (comma-separated)
-# If not set, any redirect_uri is accepted (not recommended for production)
-# MCP_REDIRECT_URIS=https://claude.ai/oauth/callback
+# If not set, any redirect_uri is accepted (not recommended for production).
+# Claude.ai uses exactly this callback — note the /api/mcp/auth_callback path;
+# an entry like https://claude.ai/oauth/callback will NOT match:
+# MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback
 
 # Enable OAuth Dynamic Client Registration (RFC 7591) — DEV ONLY.
 # Cursor and Windsurf require DCR to connect. When enabled alongside the

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ services:
       - MCP_CLIENT_ID=openclaw
       - MCP_CLIENT_SECRET=${MCP_CLIENT_SECRET}
       - MCP_ISSUER_URL=${MCP_ISSUER_URL:-}
+      - MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback
       - TRUST_PROXY=1
       - CORS_ORIGINS=https://claude.ai
     extra_hosts:
@@ -114,6 +115,8 @@ AUTH_ENABLED=true MCP_CLIENT_ID=openclaw MCP_CLIENT_SECRET=your-secret \
 > **Important:** When running behind a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel, etc.) you **must** set:
 > - `MCP_ISSUER_URL` (or `--issuer-url`) to your public HTTPS URL — otherwise OAuth metadata advertises `http://localhost:3000` and clients fail to authenticate.
 > - `TRUST_PROXY=1` (or `--trust-proxy 1`) — otherwise `express-rate-limit` rejects the proxy's `X-Forwarded-For` header and `/token` crashes with `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.
+
+> **Recommended:** Set `MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback` so authorization codes can only be delivered to Claude's callbacks. Note the exact `/api/mcp/auth_callback` path — matching is exact, and getting it wrong fails OAuth with `Unregistered redirect_uri` (see [Troubleshooting](docs/deployment.md#invalid_request--unregistered-redirect_uri-on-authorize)).
 
 See [Installation Guide](docs/installation.md) for details.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,18 @@ When auth is enabled, the server exposes these OAuth 2.1 endpoints:
 
 Dynamic client registration is **disabled by default** — only the pre-configured client (from `MCP_CLIENT_ID` + `MCP_CLIENT_SECRET`) can authenticate. This prevents anyone who knows the server URL from self-registering and bypassing auth.
 
+#### Redirect URI allow-list
+
+`MCP_REDIRECT_URIS` restricts which `redirect_uri` values the `/authorize` endpoint accepts for the pre-configured client. When unset, any redirect URI is accepted (the client secret verified during token exchange remains the actual auth gate) — set it in production so authorization codes can only be delivered to callbacks you trust.
+
+Claude.ai uses exactly this callback (note the `/api/mcp/auth_callback` path):
+
+```bash
+MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback
+```
+
+Matching is exact (scheme, host, path). A common mistake is registering `https://claude.ai/oauth/callback`, which does **not** match and makes Claude.ai fail with `Unregistered redirect_uri`. If you also connect other clients (e.g. MCP Inspector), append their callbacks to the comma-separated list — loopback callbacks (`http://localhost/...`, `http://127.0.0.1/...`) match on any port per RFC 8252.
+
 #### Cursor / Windsurf compatibility (dev only)
 
 Cursor and Windsurf only support MCP servers that expose OAuth 2.0 Dynamic Client Registration (RFC 7591). To let them connect, set `MCP_DANGEROUSLY_ALLOW_DCR=true`. The server will then advertise a `/register` endpoint and accept ad-hoc client registrations (kept in an in-memory FIFO store, capped at 100 entries).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,6 +24,7 @@ services:
       - MCP_CLIENT_SECRET=${MCP_CLIENT_SECRET:-}
       - MCP_ISSUER_URL=${MCP_ISSUER_URL:-}
       - MCP_REDIRECT_URIS=${MCP_REDIRECT_URIS:-}
+      - TRUST_PROXY=${TRUST_PROXY:-}
       - CORS_ORIGINS=${CORS_ORIGINS:-https://claude.ai}
       - NODE_ENV=production
     extra_hosts:
@@ -56,6 +57,12 @@ AUTH_ENABLED=true
 # Public URL (required when behind a reverse proxy)
 MCP_ISSUER_URL=https://mcp.your-domain.com
 
+# Trust the reverse proxy's X-Forwarded-For (required behind a reverse proxy)
+TRUST_PROXY=1
+
+# Allowed OAuth redirect URIs — Claude.ai callbacks (recommended for production)
+MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback
+
 # Allowed CORS origins
 CORS_ORIGINS=https://claude.ai
 ```
@@ -79,7 +86,7 @@ docker compose up -d
 - [ ] `MCP_CLIENT_SECRET` generated securely (`openssl rand -hex 32`, min 32 chars)
 - [ ] `MCP_ISSUER_URL` set to public HTTPS URL (when behind reverse proxy)
 - [ ] `TRUST_PROXY` set to the right hop count / CIDR (when behind reverse proxy)
-- [ ] `MCP_REDIRECT_URIS` restricted to known callback URLs
+- [ ] `MCP_REDIRECT_URIS` restricted to known callback URLs (for Claude.ai: `https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback`)
 - [ ] CORS restricted to known origins (`CORS_ORIGINS=https://claude.ai`)
 - [ ] `OPENCLAW_GATEWAY_TOKEN` set for gateway authentication
 - [ ] Dynamic client registration is disabled (default — no `/register` endpoint)
@@ -204,6 +211,18 @@ You're running behind a reverse proxy but haven't set `MCP_ISSUER_URL`. The OAut
 ### `POST /` or `GET /` returns 404 after OAuth succeeds
 
 Your Claude.ai connector URL is missing the `/mcp` path. The MCP Streamable HTTP transport is mounted at `/mcp`, not at the server root (which is intentional — root is reserved for `/health`, `/.well-known/*`, OAuth endpoints, and legacy SSE endpoints). Update the connector URL in Claude.ai to end with `/mcp`, e.g. `https://mcp.your-domain.com/mcp`.
+
+### `invalid_request` / `Unregistered redirect_uri` on `/authorize`
+
+The `redirect_uri` the client sent is not on the server's allow-list. Two common causes:
+
+1. **`MCP_REDIRECT_URIS` is set but doesn't contain the client's exact callback.** Claude.ai uses `https://claude.ai/api/mcp/auth_callback` (and `https://claude.com/api/mcp/auth_callback`) — a similar-looking entry like `https://claude.ai/oauth/callback` does **not** match. Matching is exact on scheme, host, and path; only loopback callbacks (`localhost`, `127.0.0.1`, `[::1]`) get port relaxation per RFC 8252.
+
+2. **You're on bridge ≤ 1.5.0 with `MCP_REDIRECT_URIS` unset.** The allow-any fallback in those versions was silently broken by a change in MCP SDK 1.29 (the SDK switched its membership check from `.includes()` to `.some()`), so *every* redirect_uri was rejected — fresh `npx openclaw-mcp@latest` installs picked the new SDK up automatically. Upgrade to bridge ≥ 1.6.0, or set `MCP_REDIRECT_URIS` explicitly (recommended for production anyway):
+
+```bash
+MCP_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback
+```
 
 ### `ValidationError: ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on `/token`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "openclaw-mcp",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-mcp",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
-      "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -713,14 +713,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -1654,21 +1655,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1901,9 +1915,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2101,9 +2115,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2519,10 +2533,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2960,9 +2977,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2976,7 +2993,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3071,6 +3087,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3602,9 +3627,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3824,12 +3849,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3860,12 +3886,16 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -4140,14 +4170,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -4159,13 +4189,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4646,17 +4676,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/src/__tests__/auth/oauth.test.ts
+++ b/src/__tests__/auth/oauth.test.ts
@@ -97,8 +97,30 @@ describe('OpenClawClientsStore', () => {
   it('accepts any redirect_uri for pre-configured client', async () => {
     const store = new OpenClawClientsStore({ clientId: 'test-id', clientSecret: 'test-secret' });
     const client = await store.getClient('test-id');
+    // SDK ≤1.28 membership check
     expect(client?.redirect_uris.includes('http://any-uri.com/callback')).toBe(true);
     expect(client?.redirect_uris.includes('https://claude.ai/oauth/callback')).toBe(true);
+    // SDK ≥1.29 membership check (.some(redirectUriMatches))
+    expect(
+      client?.redirect_uris.some((registered) => registered === 'http://any-uri.com/callback')
+    ).toBe(true);
+    // Empty backing list → when a client omits redirect_uri entirely, the SDK
+    // reports a validation error instead of redirecting to undefined
+    expect(client?.redirect_uris.length).toBe(0);
+  });
+
+  it('uses the explicit redirect URI list when configured', async () => {
+    const store = new OpenClawClientsStore({
+      clientId: 'test-id',
+      clientSecret: 'test-secret',
+      redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
+    });
+    const client = await store.getClient('test-id');
+    expect(client?.redirect_uris).toEqual(['https://claude.ai/api/mcp/auth_callback']);
+    expect(client?.redirect_uris.includes('https://evil.example.com/callback')).toBe(false);
+    expect(client?.redirect_uris.some((r) => r === 'https://evil.example.com/callback')).toBe(
+      false
+    );
   });
 });
 

--- a/src/__tests__/server/auth-integration.test.ts
+++ b/src/__tests__/server/auth-integration.test.ts
@@ -238,4 +238,85 @@ describe('Full OAuth flow with pre-configured client', () => {
     const body: any = await res.json();
     expect(body.error).toBe('invalid_client');
   });
+
+  it('authorize accepts the claude.ai callback with allow-any default (regression: SDK ≥1.29 uses .some())', async () => {
+    // Claude.ai sends exactly this redirect_uri. With MCP_REDIRECT_URIS unset,
+    // the allow-any fallback must accept it regardless of which membership
+    // check (.includes() / .some()) the installed SDK version uses.
+    const authorizeUrl = new URL(`${baseUrl}/authorize`);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', CLIENT_ID);
+    authorizeUrl.searchParams.set('redirect_uri', 'https://claude.ai/api/mcp/auth_callback');
+    authorizeUrl.searchParams.set('code_challenge', 'test-challenge');
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+    authorizeUrl.searchParams.set('scope', 'mcp:tools');
+
+    const res = await fetch(authorizeUrl.toString(), { redirect: 'manual' });
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.origin + location.pathname).toBe('https://claude.ai/api/mcp/auth_callback');
+    expect(location.searchParams.get('code')).toBeTruthy();
+  });
+});
+
+describe('Explicit redirect URI allow-list (MCP_REDIRECT_URIS)', () => {
+  const ALLOWED_URI = 'https://claude.ai/api/mcp/auth_callback';
+  let restrictedServer: http.Server;
+  let restrictedBaseUrl: string;
+
+  beforeAll(async () => {
+    const provider = new OpenClawAuthProvider({
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      redirectUris: [ALLOWED_URI],
+    });
+    const app = createMcpExpressApp({ host: '127.0.0.1' });
+    app.use(
+      mcpAuthRouter({
+        provider,
+        issuerUrl: new URL('http://127.0.0.1:0'),
+        scopesSupported: ['mcp:tools'],
+      })
+    );
+    await new Promise<void>((resolve) => {
+      restrictedServer = app.listen(0, '127.0.0.1', () => {
+        const addr = restrictedServer.address() as { port: number };
+        restrictedBaseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      restrictedServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  function authorizeUrlWith(redirectUri: string): string {
+    const url = new URL(`${restrictedBaseUrl}/authorize`);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', CLIENT_ID);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('code_challenge', 'test-challenge');
+    url.searchParams.set('code_challenge_method', 'S256');
+    return url.toString();
+  }
+
+  it('accepts a listed redirect_uri', async () => {
+    const res = await fetch(authorizeUrlWith(ALLOWED_URI), { redirect: 'manual' });
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.origin + location.pathname).toBe(ALLOWED_URI);
+    expect(location.searchParams.get('code')).toBeTruthy();
+  });
+
+  it('rejects an unlisted redirect_uri', async () => {
+    const res = await fetch(authorizeUrlWith('https://evil.example.com/callback'), {
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.error).toBe('invalid_request');
+  });
 });

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -69,17 +69,37 @@ const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const REFRESH_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const REAPER_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
-// An array that says "yes" to any .includes() check.
-// The SDK authorize handler validates redirect_uri against client.redirect_uris.includes().
-// For the pre-configured client we accept any redirect_uri since the real auth
-// gate is the client_secret (verified during token exchange).
-const ALLOW_ANY_REDIRECT: string[] = new Proxy([] as string[], {
-  get(target, prop) {
-    if (prop === 'includes') return () => true;
-    if (prop === 'length') return 1; // SDK checks length === 1 when redirect_uri is omitted
-    return Reflect.get(target, prop);
-  },
-});
+/**
+ * An empty redirect-URI list that reports "registered" for any requested URI.
+ *
+ * The SDK authorize handler validates the requested redirect_uri against
+ * `client.redirect_uris` — via `.includes()` up to SDK 1.28, and via
+ * `.some(redirectUriMatches)` since SDK 1.29. Both membership checks are
+ * overridden here so the allow-any fallback keeps working across SDK
+ * versions. (A Proxy faking only `.includes()` was used before; SDK 1.29's
+ * switch to `.some()` iterated the empty backing array and silently rejected
+ * every redirect_uri with "Unregistered redirect_uri".)
+ *
+ * For the pre-configured client we accept any redirect_uri since the real
+ * auth gate is the client_secret (verified during token exchange).
+ * The list stays empty (`length === 0`), so when a client omits redirect_uri
+ * entirely the SDK reports a proper validation error instead of redirecting
+ * to `undefined`.
+ */
+class AllowAnyRedirectUris extends Array<string> {
+  override includes(_searchElement: string, _fromIndex?: number): boolean {
+    return true;
+  }
+
+  override some(
+    _predicate: (value: string, index: number, array: string[]) => unknown,
+    _thisArg?: unknown
+  ): boolean {
+    return true;
+  }
+}
+
+const ALLOW_ANY_REDIRECT: string[] = new AllowAnyRedirectUris();
 
 /**
  * In-memory clients store.


### PR DESCRIPTION
Fixes #36

## Problem

With `MCP_REDIRECT_URIS` unset (the documented allow-any default), every Claude.ai OAuth attempt fails with `invalid_request` / `Unregistered redirect_uri` on fresh installs.

The allow-any fallback was a `Proxy` faking only `Array.prototype.includes()`. MCP SDK 1.29 switched the authorize handler's membership check to `.some(redirectUriMatches)`, which iterates the empty backing array — so the fallback silently rejected everything. `npx openclaw-mcp@latest` resolves the `^1.x` SDK range fresh (ignoring our lockfile, which pinned 1.25.3), so production installs broke while CI stayed green.

## Changes

- **`src/auth/provider.ts`** — replace the Proxy with an `Array` subclass overriding both `includes()` (SDK ≤1.28) and `some()` (SDK ≥1.29). The backing list stays empty, so an omitted `redirect_uri` now yields a clean validation error instead of a redirect to `undefined`.
- **`package.json`** — bump `@modelcontextprotocol/sdk` floor to `^1.29.0` so CI runs against what fresh installs actually resolve.
- **Tests** — regression coverage through the real SDK router: claude.ai callback (`https://claude.ai/api/mcp/auth_callback`) against the allow-any default, plus positive/negative coverage for an explicit `MCP_REDIRECT_URIS` allow-list. Verified the old Proxy fails these tests against SDK 1.29 (`400` instead of `302` — exactly the production symptom).
- **Docs** — `.env.example` showed `https://claude.ai/oauth/callback` as the `MCP_REDIRECT_URIS` example, which is not Claude's real callback and would itself lock Claude.ai out; corrected everywhere and added a troubleshooting entry for `Unregistered redirect_uri`.

## Compatibility

No behavior change for existing configurations:
- explicit `MCP_REDIRECT_URIS` allow-lists validate exactly as before
- DCR clients register real redirect URI arrays — untouched
- allow-any default works again on both old and new SDK generations

## Test plan

- [x] 152/152 unit + integration tests pass (SDK 1.29.0)
- [x] Old implementation fails the new regression tests with the exact production symptom
- [x] lint, typecheck, build, format:check clean