### PR TITLE
fix(security): scope async tasks to their MCP connection, disable CORS by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,13 +51,15 @@ DEBUG=false
 # CORS Configuration (HTTP transport)
 # =============================================================================
 
-# Allowed origins for CORS (comma-separated)
+# Allowed origins for CORS (comma-separated).
+# Leave unset to disable CORS entirely — that is the default, and the right
+# choice unless a browser-based client needs to reach this server directly.
 # Examples:
-#   CORS_ORIGINS=*                           # Allow all origins (not recommended for production)
-#   CORS_ORIGINS=none                        # Disable CORS entirely
+#   CORS_ORIGINS=none                        # Disable CORS entirely (same as unset)
 #   CORS_ORIGINS=https://claude.ai           # Single origin
 #   CORS_ORIGINS=https://claude.ai,https://your-app.com  # Multiple origins
 #   CORS_ORIGINS=*.example.com               # Wildcard subdomain
+#   CORS_ORIGINS=*                           # Any origin — do not use in production
 CORS_ORIGINS=https://claude.ai
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -161,8 +161,14 @@ See [Installation Guide](docs/installation.md) for details.
 |------|-------------|
 | `openclaw_chat_async` | Queue a message, get task_id immediately |
 | `openclaw_task_status` | Check task progress and get results |
-| `openclaw_task_list` | List all tasks with filtering |
+| `openclaw_task_list` | List your tasks with filtering |
 | `openclaw_task_cancel` | Cancel a pending task |
+
+Tasks are scoped to the MCP connection that created them. In HTTP mode, where
+one process serves many clients, a client can only see and cancel its own
+tasks — another client's `task_id` reads as "not found" even if it is known.
+Reconnecting starts a fresh scope, so poll a task on the connection that
+queued it.
 
 ## Multi-Instance Mode
 
@@ -261,13 +267,27 @@ AUTH_ENABLED=true MCP_CLIENT_ID=openclaw MCP_CLIENT_SECRET=$MCP_CLIENT_SECRET \
   openclaw-mcp --transport http
 ```
 
-Configure CORS to restrict access:
+CORS is disabled unless you opt in. Set `CORS_ORIGINS` only when a browser
+client needs to reach the server directly:
 
 ```bash
 CORS_ORIGINS=https://claude.ai,https://your-app.com
 ```
 
 See [Configuration](docs/configuration.md) for all security options.
+
+### Upgrading to 1.7.0
+
+Two defaults changed for security. Both only affect HTTP mode; stdio is
+unchanged.
+
+- **CORS is now off by default.** Previously an unset `CORS_ORIGINS` sent
+  `Access-Control-Allow-Origin: *`. If a browser client depends on that, set
+  the origins explicitly (`CORS_ORIGINS=https://your-app.com`), or
+  `CORS_ORIGINS=*` to restore the old behaviour.
+- **Async tasks are scoped to the connection that created them.** A client
+  that used to poll a `task_id` queued by a different connection will now get
+  "not found".
 
 ## Migrating from SSE to HTTP transport
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,17 +123,24 @@ When `TRUST_PROXY` is unset and a reverse proxy injects an `X-Forwarded-For` hea
 
 ### CORS Configuration
 
-| Variable       | Description                       | Default |
-| -------------- | --------------------------------- | ------- |
-| `CORS_ORIGINS` | Allowed origins (comma-separated) | `*`     |
+| Variable       | Description                       | Default            |
+| -------------- | --------------------------------- | ------------------ |
+| `CORS_ORIGINS` | Allowed origins (comma-separated) | _(CORS disabled)_  |
+
+CORS is **off unless you opt in**. With it off the server sends no
+`Access-Control-Allow-Origin` header, so browsers refuse cross-origin calls to
+it. Non-browser clients — Claude.ai, Claude Desktop, and anything speaking
+stdio — are unaffected; set this only when a web page has to reach the server
+directly.
 
 **CORS_ORIGINS examples:**
 
-- `*` — Allow all origins (not recommended for production)
-- `none` — Disable CORS entirely
+- _(unset)_ or `none` — CORS disabled (default)
 - `https://claude.ai` — Single origin
 - `https://claude.ai,https://your-app.com` — Multiple origins
 - `*.example.com` — Wildcard subdomain
+- `*` — Allow all origins. Lets any web page drive this server through a
+  visitor's browser; do not use in production.
 
 ### Authentication (OAuth 2.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "mcpName": "io.github.freema/openclaw-mcp",
   "description": "Model Context Protocol (MCP) server for OpenClaw AI assistant integration",
   "author": "Tomáš Grasl <https://www.tomasgrasl.cz/>",

--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/freema/openclaw-mcp",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "websiteUrl": "https://openclaw-mcp.cloud",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "openclaw-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/mcp/tasks/manager.test.ts
+++ b/src/__tests__/mcp/tasks/manager.test.ts
@@ -4,13 +4,19 @@ import { taskManager } from '../../../mcp/tasks/manager.js';
 // Suppress log output during tests
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
+// Two independent MCP connections. Most tests use OWNER; OTHER exists to prove
+// nothing leaks across the boundary.
+const OWNER = 'owner-a';
+const OTHER = 'owner-b';
+
 describe('TaskManager', () => {
   beforeEach(() => {
     // Clean up all tasks before each test.
     // The taskManager is a singleton so we need to manually clear state.
-    const allTasks = taskManager.list();
-    for (const task of allTasks) {
-      taskManager.delete(task.id);
+    for (const owner of [OWNER, OTHER]) {
+      for (const task of taskManager.list(owner)) {
+        taskManager.delete(task.id);
+      }
     }
   });
 
@@ -21,23 +27,40 @@ describe('TaskManager', () => {
 
   describe('create', () => {
     it('creates a task with pending status', () => {
-      const task = taskManager.create({ type: 'chat', input: { message: 'hello' } });
+      const task = taskManager.create({
+        type: 'chat',
+        input: { message: 'hello' },
+        ownerId: OWNER,
+      });
       expect(task.id).toMatch(/^task_/);
       expect(task.status).toBe('pending');
       expect(task.type).toBe('chat');
       expect(task.input).toEqual({ message: 'hello' });
       expect(task.priority).toBe(0);
       expect(task.createdAt).toBeInstanceOf(Date);
+      expect(task.ownerId).toBe(OWNER);
     });
 
     it('assigns unique IDs', () => {
-      const t1 = taskManager.create({ type: 'chat', input: 'a' });
-      const t2 = taskManager.create({ type: 'chat', input: 'b' });
+      const t1 = taskManager.create({ type: 'chat', input: 'a', ownerId: OWNER });
+      const t2 = taskManager.create({ type: 'chat', input: 'b', ownerId: OWNER });
       expect(t1.id).not.toBe(t2.id);
     });
 
+    it('assigns non-sequential, unguessable IDs', () => {
+      const ids = Array.from({ length: 5 }, () =>
+        taskManager.create({ type: 'chat', input: 'x', ownerId: OWNER })
+      ).map((t) => t.id);
+
+      // UUID suffix, not a counter an attacker could walk.
+      for (const id of ids) {
+        expect(id).toMatch(/^task_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
     it('respects priority option', () => {
-      const task = taskManager.create({ type: 'chat', input: 'x', priority: 5 });
+      const task = taskManager.create({ type: 'chat', input: 'x', priority: 5, ownerId: OWNER });
       expect(task.priority).toBe(5);
     });
 
@@ -46,55 +69,76 @@ describe('TaskManager', () => {
         type: 'chat',
         input: 'x',
         sessionId: 'sess-1',
+        ownerId: OWNER,
       });
       expect(task.sessionId).toBe('sess-1');
     });
   });
 
   describe('get', () => {
-    it('returns task by ID', () => {
-      const created = taskManager.create({ type: 'chat', input: 'test' });
-      const fetched = taskManager.get(created.id);
+    it('returns task by ID for its owner', () => {
+      const created = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
+      const fetched = taskManager.get(created.id, OWNER);
       expect(fetched).toBeDefined();
       expect(fetched?.id).toBe(created.id);
     });
 
     it('returns undefined for unknown ID', () => {
-      expect(taskManager.get('nonexistent')).toBeUndefined();
+      expect(taskManager.get('nonexistent', OWNER)).toBeUndefined();
+    });
+
+    it('hides tasks belonging to another owner', () => {
+      const created = taskManager.create({ type: 'chat', input: 'secret', ownerId: OWNER });
+      expect(taskManager.get(created.id, OTHER)).toBeUndefined();
     });
   });
 
   describe('list', () => {
-    it('returns all tasks', () => {
-      taskManager.create({ type: 'chat', input: '1' });
-      taskManager.create({ type: 'chat', input: '2' });
-      expect(taskManager.list()).toHaveLength(2);
+    it('returns all tasks for the owner', () => {
+      taskManager.create({ type: 'chat', input: '1', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: '2', ownerId: OWNER });
+      expect(taskManager.list(OWNER)).toHaveLength(2);
+    });
+
+    it('excludes tasks belonging to another owner', () => {
+      taskManager.create({ type: 'chat', input: 'mine', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: 'theirs', ownerId: OTHER });
+
+      expect(taskManager.list(OWNER)).toHaveLength(1);
+      expect(taskManager.list(OWNER)[0].input).toBe('mine');
+      expect(taskManager.list(OTHER)).toHaveLength(1);
+      expect(taskManager.list(OTHER)[0].input).toBe('theirs');
     });
 
     it('filters by status', () => {
-      const t1 = taskManager.create({ type: 'chat', input: '1' });
-      taskManager.create({ type: 'chat', input: '2' });
+      const t1 = taskManager.create({ type: 'chat', input: '1', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: '2', ownerId: OWNER });
       taskManager.updateStatus(t1.id, 'running');
 
-      expect(taskManager.list({ status: 'running' })).toHaveLength(1);
-      expect(taskManager.list({ status: 'pending' })).toHaveLength(1);
+      expect(taskManager.list(OWNER, { status: 'running' })).toHaveLength(1);
+      expect(taskManager.list(OWNER, { status: 'pending' })).toHaveLength(1);
     });
 
     it('filters by sessionId', () => {
-      taskManager.create({ type: 'chat', input: '1', sessionId: 'a' });
-      taskManager.create({ type: 'chat', input: '2', sessionId: 'b' });
-      taskManager.create({ type: 'chat', input: '3', sessionId: 'a' });
+      taskManager.create({ type: 'chat', input: '1', sessionId: 'a', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: '2', sessionId: 'b', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: '3', sessionId: 'a', ownerId: OWNER });
 
-      expect(taskManager.list({ sessionId: 'a' })).toHaveLength(2);
-      expect(taskManager.list({ sessionId: 'b' })).toHaveLength(1);
+      expect(taskManager.list(OWNER, { sessionId: 'a' })).toHaveLength(2);
+      expect(taskManager.list(OWNER, { sessionId: 'b' })).toHaveLength(1);
+    });
+
+    it('does not let a sessionId filter reach another owner', () => {
+      taskManager.create({ type: 'chat', input: 'theirs', sessionId: 'shared', ownerId: OTHER });
+      expect(taskManager.list(OWNER, { sessionId: 'shared' })).toHaveLength(0);
     });
 
     it('sorts by priority descending, then creation time ascending', () => {
-      const low = taskManager.create({ type: 'chat', input: '1', priority: 1 });
-      const high = taskManager.create({ type: 'chat', input: '2', priority: 10 });
-      const mid = taskManager.create({ type: 'chat', input: '3', priority: 5 });
+      const low = taskManager.create({ type: 'chat', input: '1', priority: 1, ownerId: OWNER });
+      const high = taskManager.create({ type: 'chat', input: '2', priority: 10, ownerId: OWNER });
+      const mid = taskManager.create({ type: 'chat', input: '3', priority: 5, ownerId: OWNER });
 
-      const sorted = taskManager.list();
+      const sorted = taskManager.list(OWNER);
       expect(sorted[0].id).toBe(high.id);
       expect(sorted[1].id).toBe(mid.id);
       expect(sorted[2].id).toBe(low.id);
@@ -103,40 +147,40 @@ describe('TaskManager', () => {
 
   describe('updateStatus', () => {
     it('changes task status', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       const updated = taskManager.updateStatus(task.id, 'running');
       expect(updated).toBe(true);
-      expect(taskManager.get(task.id)?.status).toBe('running');
+      expect(taskManager.get(task.id, OWNER)?.status).toBe('running');
     });
 
     it('sets startedAt when moving to running', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'running');
-      expect(taskManager.get(task.id)?.startedAt).toBeInstanceOf(Date);
+      expect(taskManager.get(task.id, OWNER)?.startedAt).toBeInstanceOf(Date);
     });
 
     it('sets completedAt for terminal statuses', () => {
-      const t1 = taskManager.create({ type: 'chat', input: '1' });
-      const t2 = taskManager.create({ type: 'chat', input: '2' });
-      const t3 = taskManager.create({ type: 'chat', input: '3' });
+      const t1 = taskManager.create({ type: 'chat', input: '1', ownerId: OWNER });
+      const t2 = taskManager.create({ type: 'chat', input: '2', ownerId: OWNER });
+      const t3 = taskManager.create({ type: 'chat', input: '3', ownerId: OWNER });
 
       taskManager.updateStatus(t1.id, 'completed');
       taskManager.updateStatus(t2.id, 'failed');
       taskManager.updateStatus(t3.id, 'cancelled');
 
-      expect(taskManager.get(t1.id)?.completedAt).toBeInstanceOf(Date);
-      expect(taskManager.get(t2.id)?.completedAt).toBeInstanceOf(Date);
-      expect(taskManager.get(t3.id)?.completedAt).toBeInstanceOf(Date);
+      expect(taskManager.get(t1.id, OWNER)?.completedAt).toBeInstanceOf(Date);
+      expect(taskManager.get(t2.id, OWNER)?.completedAt).toBeInstanceOf(Date);
+      expect(taskManager.get(t3.id, OWNER)?.completedAt).toBeInstanceOf(Date);
     });
 
     it('stores result and error', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'completed', 'result-data');
-      expect(taskManager.get(task.id)?.result).toBe('result-data');
+      expect(taskManager.get(task.id, OWNER)?.result).toBe('result-data');
 
-      const task2 = taskManager.create({ type: 'chat', input: 'test2' });
+      const task2 = taskManager.create({ type: 'chat', input: 'test2', ownerId: OWNER });
       taskManager.updateStatus(task2.id, 'failed', undefined, 'error-msg');
-      expect(taskManager.get(task2.id)?.error).toBe('error-msg');
+      expect(taskManager.get(task2.id, OWNER)?.error).toBe('error-msg');
     });
 
     it('returns false for unknown task', () => {
@@ -146,65 +190,83 @@ describe('TaskManager', () => {
 
   describe('cancel', () => {
     it('cancels a pending task', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
-      expect(taskManager.cancel(task.id)).toBe(true);
-      expect(taskManager.get(task.id)?.status).toBe('cancelled');
-      expect(taskManager.get(task.id)?.completedAt).toBeInstanceOf(Date);
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
+      expect(taskManager.cancel(task.id, OWNER)).toBe(true);
+      expect(taskManager.get(task.id, OWNER)?.status).toBe('cancelled');
+      expect(taskManager.get(task.id, OWNER)?.completedAt).toBeInstanceOf(Date);
     });
 
     it('rejects cancellation of non-pending task', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'running');
-      expect(taskManager.cancel(task.id)).toBe(false);
-      expect(taskManager.get(task.id)?.status).toBe('running');
+      expect(taskManager.cancel(task.id, OWNER)).toBe(false);
+      expect(taskManager.get(task.id, OWNER)?.status).toBe('running');
     });
 
     it('returns false for unknown task', () => {
-      expect(taskManager.cancel('nonexistent')).toBe(false);
+      expect(taskManager.cancel('nonexistent', OWNER)).toBe(false);
+    });
+
+    it("refuses to cancel another owner's task", () => {
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
+      expect(taskManager.cancel(task.id, OTHER)).toBe(false);
+      expect(taskManager.get(task.id, OWNER)?.status).toBe('pending');
     });
   });
 
   describe('getNextPending', () => {
     it('returns the highest-priority pending task', () => {
-      taskManager.create({ type: 'chat', input: '1', priority: 1 });
-      const high = taskManager.create({ type: 'chat', input: '2', priority: 10 });
+      taskManager.create({ type: 'chat', input: '1', priority: 1, ownerId: OWNER });
+      const high = taskManager.create({ type: 'chat', input: '2', priority: 10, ownerId: OWNER });
 
       const next = taskManager.getNextPending();
       expect(next?.id).toBe(high.id);
     });
 
     it('returns undefined when no pending tasks', () => {
-      const task = taskManager.create({ type: 'chat', input: '1' });
+      const task = taskManager.create({ type: 'chat', input: '1', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'running');
       expect(taskManager.getNextPending()).toBeUndefined();
+    });
+
+    it('serves every owner (worker path is intentionally unscoped)', () => {
+      const theirs = taskManager.create({
+        type: 'chat',
+        input: 'theirs',
+        priority: 10,
+        ownerId: OTHER,
+      });
+      taskManager.create({ type: 'chat', input: 'mine', priority: 1, ownerId: OWNER });
+
+      expect(taskManager.getNextPending()?.id).toBe(theirs.id);
     });
   });
 
   describe('cleanup', () => {
     it('removes completed tasks older than maxAge', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'completed');
 
       // Backdate the completedAt
-      const t = taskManager.get(task.id)!;
+      const t = taskManager.get(task.id, OWNER)!;
       t.completedAt = new Date(Date.now() - 7200_000); // 2 hours ago
 
       const cleaned = taskManager.cleanup(3600_000); // 1 hour threshold
       expect(cleaned).toBe(1);
-      expect(taskManager.get(task.id)).toBeUndefined();
+      expect(taskManager.get(task.id, OWNER)).toBeUndefined();
     });
 
     it('keeps recent completed tasks', () => {
-      const task = taskManager.create({ type: 'chat', input: 'test' });
+      const task = taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       taskManager.updateStatus(task.id, 'completed');
 
       const cleaned = taskManager.cleanup(3600_000);
       expect(cleaned).toBe(0);
-      expect(taskManager.get(task.id)).toBeDefined();
+      expect(taskManager.get(task.id, OWNER)).toBeDefined();
     });
 
     it('does not remove pending tasks', () => {
-      taskManager.create({ type: 'chat', input: 'test' });
+      taskManager.create({ type: 'chat', input: 'test', ownerId: OWNER });
       const cleaned = taskManager.cleanup(0);
       expect(cleaned).toBe(0);
     });
@@ -212,14 +274,14 @@ describe('TaskManager', () => {
 
   describe('stats', () => {
     it('returns correct counts', () => {
-      const t1 = taskManager.create({ type: 'chat', input: '1' });
-      const t2 = taskManager.create({ type: 'chat', input: '2' });
-      taskManager.create({ type: 'chat', input: '3' });
+      const t1 = taskManager.create({ type: 'chat', input: '1', ownerId: OWNER });
+      const t2 = taskManager.create({ type: 'chat', input: '2', ownerId: OWNER });
+      taskManager.create({ type: 'chat', input: '3', ownerId: OWNER });
 
       taskManager.updateStatus(t1.id, 'running');
       taskManager.updateStatus(t2.id, 'completed');
 
-      const stats = taskManager.stats();
+      const stats = taskManager.stats(OWNER);
       expect(stats.total).toBe(3);
       expect(stats.byStatus.pending).toBe(1);
       expect(stats.byStatus.running).toBe(1);
@@ -229,7 +291,16 @@ describe('TaskManager', () => {
     });
 
     it('returns zeros when empty', () => {
-      const stats = taskManager.stats();
+      const stats = taskManager.stats(OWNER);
+      expect(stats.total).toBe(0);
+      expect(stats.byStatus.pending).toBe(0);
+    });
+
+    it("does not count another owner's tasks", () => {
+      taskManager.create({ type: 'chat', input: '1', ownerId: OTHER });
+      taskManager.create({ type: 'chat', input: '2', ownerId: OTHER });
+
+      const stats = taskManager.stats(OWNER);
       expect(stats.total).toBe(0);
       expect(stats.byStatus.pending).toBe(0);
     });

--- a/src/__tests__/mcp/tools/tasks.test.ts
+++ b/src/__tests__/mcp/tools/tasks.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Handler-level isolation tests.
+ *
+ * The manager tests cover the storage layer; these drive the actual tool
+ * handlers the way a remote client would, and assert that a second connection
+ * cannot read, list or cancel the first connection's tasks even when it knows
+ * the exact task ID.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import { InstanceRegistry } from '../../../openclaw/registry.js';
+import { taskManager } from '../../../mcp/tasks/manager.js';
+import {
+  handleOpenclawChatAsync,
+  handleOpenclawTaskStatus,
+  handleOpenclawTaskList,
+  handleOpenclawTaskCancel,
+} from '../../../mcp/tools/tasks.js';
+
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+// Two MCP connections, as created per-connection in tools-registration.ts.
+const ALICE = 'conn-alice';
+const MALLORY = 'conn-mallory';
+
+function text(response: { content: Array<{ text: string }> }): string {
+  return response.content[0].text;
+}
+
+function json(response: { content: Array<{ text: string }> }): Record<string, unknown> {
+  return JSON.parse(text(response));
+}
+
+describe('async task tools — cross-connection isolation', () => {
+  let registry: InstanceRegistry;
+
+  beforeEach(() => {
+    for (const owner of [ALICE, MALLORY]) {
+      for (const task of taskManager.list(owner)) {
+        taskManager.delete(task.id);
+      }
+    }
+
+    registry = new InstanceRegistry(
+      [{ name: 'default', url: 'http://localhost:18789', default: true }],
+      'openclaw'
+    );
+
+    // The background processor would immediately pick tasks up and try to
+    // reach a gateway; keep them pending so the tests stay hermetic.
+    vi.spyOn(taskManager, 'getNextPending').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  async function queueTaskAs(ownerId: string, message: string): Promise<string> {
+    const response = await handleOpenclawChatAsync(registry, { message }, ownerId);
+    const task_id = json(response).task_id as string;
+    expect(task_id).toBeTruthy();
+    return task_id;
+  }
+
+  it('lets the owner read its own task', async () => {
+    const taskId = await queueTaskAs(ALICE, 'hello');
+
+    const response = await handleOpenclawTaskStatus(registry, { task_id: taskId }, ALICE);
+    expect(response.isError).toBeUndefined();
+    expect(json(response).task_id).toBe(taskId);
+  });
+
+  it("hides another connection's task behind the same 'not found' error", async () => {
+    const taskId = await queueTaskAs(ALICE, 'confidential prompt');
+
+    const response = await handleOpenclawTaskStatus(registry, { task_id: taskId }, MALLORY);
+    expect(response.isError).toBe(true);
+    expect(text(response)).toBe(`Error: Task not found: ${taskId}`);
+
+    // Identical wording for an ID that never existed — no existence oracle.
+    const unknown = await handleOpenclawTaskStatus(
+      registry,
+      { task_id: 'task_00000000-0000-4000-8000-000000000000' },
+      MALLORY
+    );
+    expect(text(unknown)).toBe('Error: Task not found: task_00000000-0000-4000-8000-000000000000');
+  });
+
+  it("refuses to cancel another connection's task", async () => {
+    const taskId = await queueTaskAs(ALICE, 'important work');
+
+    const response = await handleOpenclawTaskCancel(registry, { task_id: taskId }, MALLORY);
+    expect(response.isError).toBe(true);
+    expect(text(response)).toBe(`Error: Task not found: ${taskId}`);
+
+    // Still runnable for its actual owner.
+    expect(taskManager.get(taskId, ALICE)?.status).toBe('pending');
+  });
+
+  it('lets the owner cancel its own task', async () => {
+    const taskId = await queueTaskAs(ALICE, 'never mind');
+
+    const response = await handleOpenclawTaskCancel(registry, { task_id: taskId }, ALICE);
+    expect(response.isError).toBeUndefined();
+    expect(taskManager.get(taskId, ALICE)?.status).toBe('cancelled');
+  });
+
+  it('scopes task_list and its stats to the calling connection', async () => {
+    await queueTaskAs(ALICE, 'a1');
+    await queueTaskAs(ALICE, 'a2');
+    await queueTaskAs(MALLORY, 'm1');
+
+    const alice = json(await handleOpenclawTaskList(registry, {}, ALICE));
+    expect(alice.tasks).toHaveLength(2);
+    expect((alice.stats as { total: number }).total).toBe(2);
+
+    const mallory = json(await handleOpenclawTaskList(registry, {}, MALLORY));
+    expect(mallory.tasks).toHaveLength(1);
+    expect((mallory.stats as { total: number }).total).toBe(1);
+  });
+
+  it('does not leak across connections via the session_id filter', async () => {
+    await handleOpenclawChatAsync(registry, { message: 'a', session_id: 'shared' }, ALICE);
+
+    const mallory = json(await handleOpenclawTaskList(registry, { session_id: 'shared' }, MALLORY));
+    expect(mallory.tasks).toHaveLength(0);
+  });
+
+  it('never exposes ownerId to the client', async () => {
+    const taskId = await queueTaskAs(ALICE, 'hello');
+
+    const status = text(await handleOpenclawTaskStatus(registry, { task_id: taskId }, ALICE));
+    const list = text(await handleOpenclawTaskList(registry, {}, ALICE));
+
+    expect(status).not.toContain(ALICE);
+    expect(status).not.toContain('ownerId');
+    expect(list).not.toContain(ALICE);
+    expect(list).not.toContain('ownerId');
+  });
+});

--- a/src/__tests__/server/http.test.ts
+++ b/src/__tests__/server/http.test.ts
@@ -10,14 +10,21 @@ describe('loadCorsConfig', () => {
     vi.unstubAllEnvs();
   });
 
-  it('returns wildcard when env is undefined', () => {
+  it('disables CORS when env is undefined', () => {
     delete process.env.CORS_ORIGINS;
     const config = loadCorsConfig();
-    expect(config.origins).toEqual(['*']);
-    expect(config.enabled).toBe(true);
+    expect(config.origins).toEqual([]);
+    expect(config.enabled).toBe(false);
   });
 
-  it('returns wildcard for "*"', () => {
+  it('disables CORS for an empty value', () => {
+    vi.stubEnv('CORS_ORIGINS', '');
+    const config = loadCorsConfig();
+    expect(config.origins).toEqual([]);
+    expect(config.enabled).toBe(false);
+  });
+
+  it('returns wildcard only when explicitly opted in with "*"', () => {
     vi.stubEnv('CORS_ORIGINS', '*');
     const config = loadCorsConfig();
     expect(config.origins).toEqual(['*']);
@@ -26,6 +33,13 @@ describe('loadCorsConfig', () => {
 
   it('disables CORS for "none"', () => {
     vi.stubEnv('CORS_ORIGINS', 'none');
+    const config = loadCorsConfig();
+    expect(config.origins).toEqual([]);
+    expect(config.enabled).toBe(false);
+  });
+
+  it('disables CORS for "NONE" regardless of case', () => {
+    vi.stubEnv('CORS_ORIGINS', 'NONE');
     const config = loadCorsConfig();
     expect(config.origins).toEqual([]);
     expect(config.enabled).toBe(false);

--- a/src/mcp/tasks/manager.ts
+++ b/src/mcp/tasks/manager.ts
@@ -3,7 +3,18 @@
  *
  * Manages background tasks with status tracking, allowing
  * long-running operations to be started and polled for results.
+ *
+ * Ownership
+ * ---------
+ * The manager is a process-wide singleton, but in HTTP mode a single process
+ * serves many independent MCP connections. Every task is therefore tagged with
+ * the `ownerId` of the connection that created it, and every read/write path
+ * reachable from a tool handler requires that same `ownerId`. A caller can
+ * never observe or mutate a task belonging to another connection, even when it
+ * knows (or guesses) the task ID.
  */
+
+import { randomUUID } from 'node:crypto';
 
 import { log } from '../../utils/logger.js';
 
@@ -23,6 +34,8 @@ export interface Task {
   createdAt: Date;
   startedAt?: Date;
   completedAt?: Date;
+  /** Connection that owns this task. Never exposed to clients. */
+  ownerId: string;
   sessionId?: string;
   instanceId?: string;
   priority: number;
@@ -31,6 +44,8 @@ export interface Task {
 export interface TaskCreateOptions {
   type: 'chat';
   input: unknown;
+  /** Connection creating the task — required, see "Ownership" above. */
+  ownerId: string;
   sessionId?: string;
   instanceId?: string;
   priority?: number;
@@ -38,7 +53,6 @@ export interface TaskCreateOptions {
 
 class TaskManager {
   private tasks: Map<string, Task> = new Map();
-  private taskCounter = 0;
   private cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor() {
@@ -49,17 +63,18 @@ class TaskManager {
   }
 
   /**
-   * Generate unique task ID
+   * Generate an unguessable task ID.
+   *
+   * Deliberately not sequential: a predictable counter would let a caller
+   * enumerate IDs and probe for tasks it does not own. Ownership checks are
+   * the real defence, this just removes the oracle.
    */
   private generateId(): string {
-    this.taskCounter++;
-    const timestamp = Date.now().toString(36);
-    const counter = this.taskCounter.toString(36).padStart(4, '0');
-    return `task_${timestamp}_${counter}`;
+    return `task_${randomUUID()}`;
   }
 
   /**
-   * Create a new task
+   * Create a new task owned by `options.ownerId`.
    */
   create(options: TaskCreateOptions): Task {
     if (this.tasks.size >= MAX_TASKS) {
@@ -75,6 +90,7 @@ class TaskManager {
       status: 'pending',
       input: options.input,
       createdAt: new Date(),
+      ownerId: options.ownerId,
       sessionId: options.sessionId,
       instanceId: options.instanceId,
       priority: options.priority ?? 0,
@@ -86,17 +102,25 @@ class TaskManager {
   }
 
   /**
-   * Get task by ID
+   * Get a task by ID, but only if `ownerId` owns it.
+   *
+   * Returns undefined both for unknown IDs and for tasks owned by someone
+   * else, so callers cannot distinguish the two.
    */
-  get(id: string): Task | undefined {
-    return this.tasks.get(id);
+  get(id: string, ownerId: string): Task | undefined {
+    const task = this.tasks.get(id);
+    if (!task || task.ownerId !== ownerId) return undefined;
+    return task;
   }
 
   /**
-   * List all tasks, optionally filtered by status
+   * List the tasks owned by `ownerId`, optionally filtered further.
    */
-  list(filter?: { status?: TaskStatus; sessionId?: string; instanceId?: string }): Task[] {
-    let tasks = Array.from(this.tasks.values());
+  list(
+    ownerId: string,
+    filter?: { status?: TaskStatus; sessionId?: string; instanceId?: string }
+  ): Task[] {
+    let tasks = Array.from(this.tasks.values()).filter((t) => t.ownerId === ownerId);
 
     if (filter?.status) {
       tasks = tasks.filter((t) => t.status === filter.status);
@@ -116,7 +140,10 @@ class TaskManager {
   }
 
   /**
-   * Update task status
+   * Update task status.
+   *
+   * Internal worker path only — never reachable from a tool handler, so it
+   * takes no ownerId.
    */
   updateStatus(id: string, status: TaskStatus, result?: string, error?: string): boolean {
     const task = this.tasks.get(id);
@@ -140,10 +167,10 @@ class TaskManager {
   }
 
   /**
-   * Cancel a pending task
+   * Cancel a pending task owned by `ownerId`.
    */
-  cancel(id: string): boolean {
-    const task = this.tasks.get(id);
+  cancel(id: string, ownerId: string): boolean {
+    const task = this.get(id, ownerId);
     if (!task) return false;
 
     if (task.status !== 'pending') {
@@ -157,17 +184,25 @@ class TaskManager {
   }
 
   /**
-   * Delete a task (cleanup)
+   * Delete a task (cleanup). Internal only.
    */
   delete(id: string): boolean {
     return this.tasks.delete(id);
   }
 
   /**
-   * Get next pending task (for workers)
+   * Get next pending task across all owners (for the background worker).
+   *
+   * Internal only — the worker has to see every queue, which is exactly why
+   * tool handlers must go through the owner-scoped methods instead.
    */
   getNextPending(): Task | undefined {
-    const pending = this.list({ status: 'pending' });
+    const pending = Array.from(this.tasks.values())
+      .filter((t) => t.status === 'pending')
+      .sort((a, b) => {
+        if (b.priority !== a.priority) return b.priority - a.priority;
+        return a.createdAt.getTime() - b.createdAt.getTime();
+      });
     return pending[0];
   }
 
@@ -192,9 +227,12 @@ class TaskManager {
   }
 
   /**
-   * Get statistics
+   * Get statistics for the tasks owned by `ownerId`.
+   *
+   * Scoped like everything else: a global total would leak how busy other
+   * connections are.
    */
-  stats(): { total: number; byStatus: Record<TaskStatus, number> } {
+  stats(ownerId: string): { total: number; byStatus: Record<TaskStatus, number> } {
     const byStatus: Record<TaskStatus, number> = {
       pending: 0,
       running: 0,
@@ -203,14 +241,14 @@ class TaskManager {
       cancelled: 0,
     };
 
+    let total = 0;
     for (const task of this.tasks.values()) {
+      if (task.ownerId !== ownerId) continue;
       byStatus[task.status]++;
+      total++;
     }
 
-    return {
-      total: this.tasks.size,
-      byStatus,
-    };
+    return { total, byStatus };
   }
 }
 

--- a/src/mcp/tools/tasks.ts
+++ b/src/mcp/tools/tasks.ts
@@ -158,7 +158,8 @@ export function startTaskProcessor(registry: InstanceRegistry): void {
 
 export async function handleOpenclawChatAsync(
   registry: InstanceRegistry,
-  input: unknown
+  input: unknown,
+  ownerId: string
 ): Promise<ToolResponse> {
   if (!validateInputIsObject(input)) {
     return errorResponse('Invalid input: expected an object');
@@ -210,6 +211,7 @@ export async function handleOpenclawChatAsync(
   const task = taskManager.create({
     type: 'chat',
     input: { message: msgResult.value, session_id: sessionId },
+    ownerId,
     sessionId,
     priority,
     instanceId,
@@ -231,7 +233,8 @@ export async function handleOpenclawChatAsync(
 
 export async function handleOpenclawTaskStatus(
   _registry: InstanceRegistry,
-  input: unknown
+  input: unknown,
+  ownerId: string
 ): Promise<ToolResponse> {
   if (!validateInputIsObject(input)) {
     return errorResponse('Invalid input: expected an object');
@@ -243,7 +246,9 @@ export async function handleOpenclawTaskStatus(
   }
   const task_id = tidResult.value;
 
-  const task = taskManager.get(task_id);
+  // Tasks owned by another connection read as "not found" — same message as a
+  // genuinely unknown ID, so this cannot be used to probe for their existence.
+  const task = taskManager.get(task_id, ownerId);
   if (!task) {
     return errorResponse(`Task not found: ${task_id}`);
   }
@@ -282,7 +287,8 @@ const VALID_TASK_STATUSES: readonly TaskStatus[] = [
 
 export async function handleOpenclawTaskList(
   _registry: InstanceRegistry,
-  input: unknown
+  input: unknown,
+  ownerId: string
 ): Promise<ToolResponse> {
   if (!validateInputIsObject(input)) {
     return errorResponse('Invalid input: expected an object');
@@ -317,8 +323,12 @@ export async function handleOpenclawTaskList(
     instanceFilter = instResult.value;
   }
 
-  const tasks = taskManager.list({ status, sessionId: session_id, instanceId: instanceFilter });
-  const stats = taskManager.stats();
+  const tasks = taskManager.list(ownerId, {
+    status,
+    sessionId: session_id,
+    instanceId: instanceFilter,
+  });
+  const stats = taskManager.stats(ownerId);
 
   const taskList = tasks.map((t) => ({
     task_id: t.id,
@@ -344,7 +354,8 @@ export async function handleOpenclawTaskList(
 
 export async function handleOpenclawTaskCancel(
   _registry: InstanceRegistry,
-  input: unknown
+  input: unknown,
+  ownerId: string
 ): Promise<ToolResponse> {
   if (!validateInputIsObject(input)) {
     return errorResponse('Invalid input: expected an object');
@@ -356,7 +367,9 @@ export async function handleOpenclawTaskCancel(
   }
   const task_id = tidResult.value;
 
-  const task = taskManager.get(task_id);
+  // Same as task_status: another connection's task is indistinguishable from
+  // an unknown one.
+  const task = taskManager.get(task_id, ownerId);
   if (!task) {
     return errorResponse(`Task not found: ${task_id}`);
   }
@@ -367,7 +380,7 @@ export async function handleOpenclawTaskCancel(
     );
   }
 
-  const cancelled = taskManager.cancel(task_id);
+  const cancelled = taskManager.cancel(task_id, ownerId);
   if (!cancelled) {
     return errorResponse('Failed to cancel task');
   }

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -69,17 +69,24 @@ export function parseTrustProxy(value: string | undefined): boolean | number | s
 // --- CORS helpers ---
 
 /**
- * Load CORS configuration from environment
+ * Load CORS configuration from environment.
+ *
+ * Defaults to CORS disabled. Sending `Access-Control-Allow-Origin: *` by
+ * default let any web page drive this server through a visitor's browser;
+ * enabling cross-origin access is now an explicit opt-in via `CORS_ORIGINS`.
+ * Set `CORS_ORIGINS=*` to restore the old behaviour, or list the origins you
+ * actually serve. Non-browser clients (Claude.ai, Claude Desktop, Inspector
+ * over stdio) are unaffected — CORS only applies to browsers.
  */
 export function loadCorsConfig(): { origins: string[]; enabled: boolean } {
   const corsOrigins = process.env.CORS_ORIGINS;
 
-  if (!corsOrigins || corsOrigins === '*') {
-    return { origins: ['*'], enabled: true };
+  if (!corsOrigins || corsOrigins.toLowerCase() === 'none') {
+    return { origins: [], enabled: false };
   }
 
-  if (corsOrigins.toLowerCase() === 'none' || corsOrigins === '') {
-    return { origins: [], enabled: false };
+  if (corsOrigins === '*') {
+    return { origins: ['*'], enabled: true };
   }
 
   return {
@@ -354,6 +361,13 @@ export async function createHttpServer(
     log(`HTTP server listening on ${config.host}:${config.port}`);
     log(`Auth enabled: ${authEnabled}`);
     log(`CORS origins: ${corsConfig.enabled ? corsConfig.origins.join(', ') : 'disabled'}`);
+
+    if (corsConfig.origins.includes('*')) {
+      logError(
+        'WARNING: CORS_ORIGINS=* allows any web page to call this server from a browser. ' +
+          'List explicit origins instead.'
+      );
+    }
 
     if (authEnabled) {
       log('OAuth 2.1 authentication is REQUIRED for all connections');

--- a/src/server/tools-registration.ts
+++ b/src/server/tools-registration.ts
@@ -6,6 +6,8 @@
  * that registration logic into a reusable function.
  */
 
+import { randomUUID } from 'node:crypto';
+
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
@@ -49,6 +51,14 @@ export function createMcpServer(deps: ToolRegistrationDeps): Server {
 function registerTools(server: Server, deps: ToolRegistrationDeps): void {
   const { registry } = deps;
 
+  // Identity of this MCP connection, used to scope async tasks.
+  //
+  // In stdio mode there is exactly one Server for the process lifetime, so
+  // behaviour is unchanged. In HTTP mode createMcpServer() is called once per
+  // connection, so each client gets its own namespace and cannot reach another
+  // client's tasks.
+  const ownerId = randomUUID();
+
   const toolHandlers = new Map<
     string,
     (
@@ -57,10 +67,10 @@ function registerTools(server: Server, deps: ToolRegistrationDeps): void {
   >([
     ['openclaw_chat', (input) => tools.handleOpenclawChat(registry, input)],
     ['openclaw_status', (input) => tools.handleOpenclawStatus(registry, input)],
-    ['openclaw_chat_async', (input) => tools.handleOpenclawChatAsync(registry, input)],
-    ['openclaw_task_status', (input) => tools.handleOpenclawTaskStatus(registry, input)],
-    ['openclaw_task_list', (input) => tools.handleOpenclawTaskList(registry, input)],
-    ['openclaw_task_cancel', (input) => tools.handleOpenclawTaskCancel(registry, input)],
+    ['openclaw_chat_async', (input) => tools.handleOpenclawChatAsync(registry, input, ownerId)],
+    ['openclaw_task_status', (input) => tools.handleOpenclawTaskStatus(registry, input, ownerId)],
+    ['openclaw_task_list', (input) => tools.handleOpenclawTaskList(registry, input, ownerId)],
+    ['openclaw_task_cancel', (input) => tools.handleOpenclawTaskCancel(registry, input, ownerId)],
     ['openclaw_instances', (input) => tools.handleOpenclawInstances(registry, input)],
   ]);
 


### PR DESCRIPTION
Closes the two task-isolation advisories (GHSA-j2fg-4r2j-424f, GHSA-c4qg-mg2r-2c56) and the wildcard-CORS half of GHSA-xp77-pwm3-v4qr.

## The problem

In HTTP mode one process serves many independent MCP connections, but `taskManager` was a flat process-wide map:

- `openclaw_task_status` and `openclaw_task_cancel` resolved a task by ID alone — no check that the caller created it.
- `openclaw_task_list` returned every task in the process, and `stats()` counted them all.
- IDs were `task_<base36 timestamp>_<base36 sequential counter>`, so they did not even need to be leaked, just counted up to.

Net effect: any connected client could read another client's prompt and result, or cancel its in-flight work.

`loadCorsConfig()` separately defaulted to `Access-Control-Allow-Origin: *` whenever `CORS_ORIGINS` was unset, which let any web page drive the server through a visitor's browser.

## The fix

Each `Server` instance — one per MCP connection, see `createMcpServer` — gets a random `ownerId` at registration time. Tasks record it, and every path reachable from a tool handler requires it:

| Method | Before | After |
| --- | --- | --- |
| `get(id)` | any task | `get(id, ownerId)`, foreign -> `undefined` |
| `list(filter)` | all tasks | `list(ownerId, filter)` |
| `cancel(id)` | any task | `cancel(id, ownerId)` |
| `stats()` | process-wide | `stats(ownerId)` |
| `updateStatus`, `getNextPending` | — | unchanged, internal worker path |

A foreign task returns the same `Task not found: <id>` as an unknown one, so the handlers give no existence oracle. Task IDs are now `task_<uuid>`, removing the enumeration shortcut on top of the ownership check.

CORS is now opt-in: unset or `none` sends no CORS headers, and `CORS_ORIGINS=*` still works but logs a warning at startup.

## Verification

Beyond unit tests, both behaviours were driven against a live server over two real Streamable HTTP sessions.

On 1.6.0:

```
alice queued task: task_ms1hrh1o_0001
mallory reads alice task   -> {"task_id":"task_ms1hrh1o_0001","status":"pending",...}
mallory cancels alice task -> {"status":"cancelled","message":"Task cancelled successfully"}
mallory task_list          -> {"stats":{"total":1,...}}
```

After this change:

```
alice queued task: task_cde960e8-0329-46d2-84a1-138a10a11516
mallory reads alice task   -> Error: Task not found: task_cde960e8-...
mallory cancels alice task -> Error: Task not found: task_cde960e8-...
mallory task_list          -> {"stats":{"total":0,...}}
alice reads her own task   -> status: pending, task_id matches: true
```

## Tests

168 passing. New coverage:

- `src/__tests__/mcp/tools/tasks.test.ts` — drives the handlers as two connections would: cross-connection read, cancel, list, `session_id` filter bypass, and that `ownerId` never reaches the client.
- `manager.test.ts` — ownership on `get`/`list`/`cancel`/`stats`, non-sequential IDs, and that `getNextPending` stays deliberately unscoped.
- `http.test.ts` — CORS default, empty value, case-insensitive `none`, explicit `*`.

## Compatibility

Minor bump to 1.7.0 rather than a patch: two HTTP-mode defaults change.

- Browser clients relying on the implicit wildcard need `CORS_ORIGINS` set explicitly.
- A client polling a `task_id` queued on a different connection now gets "not found". Reconnecting starts a fresh scope.

stdio is unaffected — one connection per process means one owner. Both notes are in the README under *Upgrading to 1.7.0*.

## Follow-up

Advisories still need `patched_versions: 1.7.0` and publishing. GHSA-f99f-69fc-572v (unauthenticated access in Docker/HTTP mode) is about the `AUTH_ENABLED` default and is not addressed here.